### PR TITLE
Add constant stories and update colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ typings/
 # Serverless directories
 .serverless
 
+# DS Store files
+**/.DS_Store
+
 # build files
 dist/
 lib/

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -1,0 +1,12 @@
+# CONSTANTS
+### Usage
+
+```jsx
+import { SPACING } from 'radiance-ui/lib/constants';
+
+<div css={`padding: ${SPACING.small}`}>Hello World!</div>
+```
+
+The following displays named imports and available values.
+
+<!-- STORY -->

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
     "husky": "^1.1.2",
+    "isobject": "^3.0.1",
     "jest": "^23.6.0",
     "lint-staged": "^7.3.0",
     "lodash.round": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
     "husky": "^1.1.2",
-    "isobject": "^3.0.1",
     "jest": "^23.6.0",
     "lint-staged": "^7.3.0",
     "lodash.round": "^4.0.4",

--- a/src/constants/colors/index.js
+++ b/src/constants/colors/index.js
@@ -60,7 +60,6 @@ export const colorAliases = {
   purple: brandColors.purple100,
   purpleTint1: brandColors.purple80,
   purpleTint2: brandColors.purple60,
-  purpleTint3: brandColors.purple40,
 
   // brand colors
   primary: brandColors.purple100,
@@ -111,7 +110,6 @@ export const postcardColors = {
   postcardOrange: legacyColors.orange,
   postcardBlack: '#414141',
   postcardGrey: '#bfc6cb',
-  postcardPurple: legacyColors.purple,
   postcardYellow: brandColors.yellow,
 };
 

--- a/src/constants/colors/index.js
+++ b/src/constants/colors/index.js
@@ -29,12 +29,16 @@ export const brandColors = {
   // Status
   statusGreen: '#317f3b',
   statusGreenBackground: '#eaf2eb',
+  statusGreenBorder: '#DAECDC',
   statusPurple: '#a6a1e2',
   statusPurpleBackground: '#f6f5fc',
+  statusPurpleBorder: '#EBEAF9',
   statusRed: '#ff5e4d',
   statusRedBackground: '#ffeeed',
+  statusRedBorder: '#FFE4E2',
   statusGrey: '#858298',
   statusGreyBackground: '#ededf0',
+  statusGreyBorder: '#e1e0e6',
 
   // Misc
   black: '#000000',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,3 @@
 export * from './colors';
 export { default as throwOnUndefinedProperty } from './throwOnUndefinedProperty';
+export { default as isObject } from './isObject';

--- a/src/utils/isObject/index.js
+++ b/src/utils/isObject/index.js
@@ -1,0 +1,5 @@
+export default val => (
+  val != null &&
+    typeof val === 'object' &&
+      Array.isArray(val) === false
+);

--- a/src/utils/isObject/test.js
+++ b/src/utils/isObject/test.js
@@ -1,0 +1,18 @@
+import isObject from './index';
+
+test('returns true for objects', () => {
+  expect(isObject({foo: 'bar'})).toBe(true);
+  expect(isObject({})).toBe(true);
+  expect(isObject(Object.create(null))).toBe(true);
+
+  const Thing = () => {};
+  expect(isObject(new Thing)).toBe(true);
+});
+
+test('returns false for non-objects', () => {
+  expect(isObject('hello')).toBe(false);
+  expect(isObject(1)).toBe(false);
+  expect(isObject(null)).toBe(false);
+  expect(isObject(undefined)).toBe(false);
+  expect(isObject([])).toBe(false);
+});

--- a/src/utils/throwOnUndefinedProperty/index.js
+++ b/src/utils/throwOnUndefinedProperty/index.js
@@ -1,6 +1,10 @@
 export default function throwOnUndefinedProperty(obj) {
   const handler = {
     get(target, property) {
+      if (property === "__isProxy") {
+        return true;
+      }
+
       if (property in target) {
         return target[property];
       }

--- a/stories/constants/Color.js
+++ b/stories/constants/Color.js
@@ -7,10 +7,8 @@ const ColorContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-
-  padding: 16px;
-
   flex: 1;
+  padding: 16px;
 `;
 
 const ColorSample = styled.div`

--- a/stories/constants/Color.js
+++ b/stories/constants/Color.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+
+const ColorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  padding: 16px;
+
+  flex: 1;
+`;
+
+const ColorSample = styled.div`
+  height: 25px;
+  width: 25px;
+  background-color: ${props => props.color};
+  border-radius: 99999px;
+  border: 1px solid #000;
+  overflow: hidden;
+`;
+
+const ColorName = styled.div`
+  font-size: 12px;
+  padding-top: 8px;
+`;
+
+const ColorHex = styled.div`
+  font-size: 8px;
+`;
+
+const Color = ({ colorName, colorHex }) => (
+  <ColorContainer>
+    <ColorSample color={colorHex} />
+    <ColorName>{colorName}</ColorName>
+    <ColorHex>{colorHex}</ColorHex>
+  </ColorContainer>
+);
+
+Color.propTypes = {
+  colorName: PropTypes.string.isRequired,
+  colorHex: PropTypes.string.isRequired,
+};
+export default Color;

--- a/stories/constants/index.js
+++ b/stories/constants/index.js
@@ -12,13 +12,17 @@ import Color from './Color';
 
 const stories = storiesOf('CONSTANTS', module);
 
+const CONSTANTS_WITH_OWN_STORY = [
+  'COLORS',
+];
+
 stories.add(
   'available constants',
   withDocs(ConstantsReadme, () => (
     <div css="text-align: left;">
       {
         Object.keys(CONSTANTS).map(category => {
-          if (['COLORS'].includes(category)) {
+          if (CONSTANTS_WITH_OWN_STORY.includes(category)) {
             // COLORS is handled on its own story
             return null;
           }

--- a/stories/constants/index.js
+++ b/stories/constants/index.js
@@ -1,63 +1,58 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import isObject from 'isobject';
 
+import * as COLORS from 'src/constants/colors';
 import * as CONSTANTS from 'src/constants';
 import { Typography } from 'src/shared-components';
 
+import renderConstantsMap from './renderConstantsMap';
+import Color from './Color';
+
 const stories = storiesOf('CONSTANTS', module);
 
-const renderConstants = constantMap => {
-  let sanitizedMap = constantMap;
+stories.add('available constants', () => (
+  <div>
+    {
+      Object.keys(CONSTANTS).map(category => {
+        if (['COLORS'].includes(category)) {
+          // COLORS is handled on its own story
+          return null;
+        }
 
-  if (constantMap.__isProxy) {
-    sanitizedMap = Object.assign({}, constantMap);
-  }
+        const categoryConstant = CONSTANTS[category];
 
-  sanitizedMap = Object.entries(sanitizedMap).reduce((memo, [key, value]) => {
-    const newMemo = Object.assign({}, memo);
-
-    if (isObject(value)) {
-      const sanitizedValue = value.__isProxy ? Object.assign({}, value) : value;
-
-      Object.entries(sanitizedValue).forEach(([innerKey, innerValue]) => {
-        newMemo[`${key}.${innerKey}`] = innerValue;
-      });
-    } else {
-      newMemo[key] = value;
+        return (
+          <div css={`padding-bottom: ${CONSTANTS.SPACING.small};`}>
+            <Typography.Heading>{category}</Typography.Heading>
+            {renderConstantsMap(categoryConstant)}
+          </div>
+        );
+      })
     }
+  </div>
+));
 
-    return newMemo;
-  }, {});
-
-  return (
-    Object.keys(sanitizedMap).map(constant => (
-      <p><strong>{constant}</strong>: {sanitizedMap[constant]}</p>
-    ))
-  );
-};
-
-stories.add(
-  'available constants',
-  () => (
-    <div>
-      {
-        Object.keys(CONSTANTS).map(category => {
-          if (['COLORS'].includes(category)) {
-            // COLORS is handled on its own story
-            return null;
-          }
-
-          const categoryConstant = CONSTANTS[category];
-
-          return (
-            <div css={`padding-bottom: ${CONSTANTS.SPACING.small};`}>
-              <Typography.Heading>{category}</Typography.Heading>
-              {renderConstants(categoryConstant)}
-            </div>
-          );
-        })
+stories.add('COLORS', () => (
+  <React.Fragment>
+    {Object.keys(COLORS).map(category => {
+      if (category === 'default') {
+        return null;
       }
-    </div>
-  )
-);
+
+      const categoryColors = COLORS[category];
+
+      return (
+        <React.Fragment>
+          <div css="font-size: 16px;">{category}</div>
+          <div css="display: flex; flex-wrap: wrap;">
+            {Object.keys(categoryColors).map(color => {
+              const colorHex = categoryColors[color];
+              return <Color colorName={color} colorHex={colorHex} />;
+            })}
+          </div>
+          <br />
+        </React.Fragment>
+      );
+    })}
+  </React.Fragment>
+));

--- a/stories/constants/index.js
+++ b/stories/constants/index.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import isObject from 'isobject';
+
+import * as CONSTANTS from 'src/constants';
+import { Typography } from 'src/shared-components';
+
+const stories = storiesOf('CONSTANTS', module);
+
+const renderConstants = constantMap => {
+  let sanitizedMap = constantMap;
+
+  if (constantMap.__isProxy) {
+    sanitizedMap = Object.assign({}, constantMap);
+  }
+
+  sanitizedMap = Object.entries(sanitizedMap).reduce((memo, [key, value]) => {
+    const newMemo = Object.assign({}, memo);
+
+    if (isObject(value)) {
+      const sanitizedValue = value.__isProxy ? Object.assign({}, value) : value;
+
+      Object.entries(sanitizedValue).forEach(([innerKey, innerValue]) => {
+        newMemo[`${key}.${innerKey}`] = innerValue;
+      });
+    } else {
+      newMemo[key] = value;
+    }
+
+    return newMemo;
+  }, {});
+
+  return (
+    Object.keys(sanitizedMap).map(constant => (
+      <p><strong>{constant}</strong>: {sanitizedMap[constant]}</p>
+    ))
+  );
+};
+
+stories.add(
+  'available constants',
+  () => (
+    <div>
+      {
+        Object.keys(CONSTANTS).map(category => {
+          if (['COLORS'].includes(category)) {
+            // COLORS is handled on its own story
+            return null;
+          }
+
+          const categoryConstant = CONSTANTS[category];
+
+          return (
+            <div css={`padding-bottom: ${CONSTANTS.SPACING.small};`}>
+              <Typography.Heading>{category}</Typography.Heading>
+              {renderConstants(categoryConstant)}
+            </div>
+          );
+        })
+      }
+    </div>
+  )
+);

--- a/stories/constants/index.js
+++ b/stories/constants/index.js
@@ -23,7 +23,6 @@ stories.add(
       {
         Object.keys(CONSTANTS).map(category => {
           if (CONSTANTS_WITH_OWN_STORY.includes(category)) {
-            // COLORS is handled on its own story
             return null;
           }
 

--- a/stories/constants/index.js
+++ b/stories/constants/index.js
@@ -1,36 +1,41 @@
 import React from 'react';
+import { withDocs } from 'storybook-readme';
 import { storiesOf } from '@storybook/react';
 
 import * as COLORS from 'src/constants/colors';
 import * as CONSTANTS from 'src/constants';
 import { Typography } from 'src/shared-components';
+import ConstantsReadme from 'docs/constants.md';
 
 import renderConstantsMap from './renderConstantsMap';
 import Color from './Color';
 
 const stories = storiesOf('CONSTANTS', module);
 
-stories.add('available constants', () => (
-  <div>
-    {
-      Object.keys(CONSTANTS).map(category => {
-        if (['COLORS'].includes(category)) {
-          // COLORS is handled on its own story
-          return null;
-        }
+stories.add(
+  'available constants',
+  withDocs(ConstantsReadme, () => (
+    <div css="text-align: left;">
+      {
+        Object.keys(CONSTANTS).map(category => {
+          if (['COLORS'].includes(category)) {
+            // COLORS is handled on its own story
+            return null;
+          }
 
-        const categoryConstant = CONSTANTS[category];
+          const categoryConstant = CONSTANTS[category];
 
-        return (
-          <div css={`padding-bottom: ${CONSTANTS.SPACING.small};`}>
-            <Typography.Heading>{category}</Typography.Heading>
-            {renderConstantsMap(categoryConstant)}
-          </div>
-        );
-      })
-    }
-  </div>
-));
+          return (
+            <div css={`padding-bottom: ${CONSTANTS.SPACING.small};`}>
+              <Typography.Heading>{category}</Typography.Heading>
+              {renderConstantsMap(categoryConstant)}
+            </div>
+          );
+        })
+      }
+    </div>
+  ))
+);
 
 stories.add('COLORS', () => (
   <React.Fragment>

--- a/stories/constants/renderConstantsMap.js
+++ b/stories/constants/renderConstantsMap.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import isObject from 'isobject';
+
+const renderConstantsMap = constantMap => {
+  let sanitizedMap = constantMap;
+
+  if (constantMap.__isProxy) {
+    sanitizedMap = Object.assign({}, constantMap);
+  }
+
+  sanitizedMap = Object.entries(sanitizedMap).reduce((memo, [key, value]) => {
+    const newMemo = Object.assign({}, memo);
+
+    if (isObject(value)) {
+      const sanitizedValue = value.__isProxy ? Object.assign({}, value) : value;
+
+      Object.entries(sanitizedValue).forEach(([innerKey, innerValue]) => {
+        newMemo[`${key}.${innerKey}`] = innerValue;
+      });
+    } else {
+      newMemo[key] = value;
+    }
+
+    return newMemo;
+  }, {});
+
+  return (
+    Object.keys(sanitizedMap).map(constant => (
+      <p><strong>{constant}</strong>: {sanitizedMap[constant]}</p>
+    ))
+  );
+};
+
+export default renderConstantsMap;


### PR DESCRIPTION
Colors:
<img width="1792" alt="screen shot 2018-10-29 at 9 01 50 pm" src="https://user-images.githubusercontent.com/9381931/47695176-00e3d300-dbbe-11e8-8962-da5fc3382158.png">

Not pretty, but a way to dynamically list all constant import names and key value pairs.
<img width="1792" alt="screen shot 2018-10-29 at 9 11 56 pm" src="https://user-images.githubusercontent.com/9381931/47695446-51a7fb80-dbbf-11e8-849e-f10280cfbb4f.png">

