### PR TITLE
rename some Typography components

### DIFF
--- a/docs/typography.md
+++ b/docs/typography.md
@@ -10,10 +10,10 @@ import { Typography } from 'radiance-ui';
 <p>Body</p>
 <Typography.Caption>Caption</Typography.Caption>
 <Typography.Label>Label</Typography.Label>
-<Typography.ErrorText>ErrorText</Typography.ErrorText>
-<Typography.SuccessText>SuccessText</Typography.SuccessText>
-<Typography.LinkTag>LinkTag</Typography.LinkTag>
-<Typography.ButtonText>ButtonText</Typography.ButtonText>
+<Typography.Error>Error</Typography.Error>
+<Typography.Success>Success</Typography.Success>
+<Typography.Link>Link</Typography.Link>
+<Typography.Button>Button</Typography.Button>
 ```
 
 <!-- STORY -->

--- a/src/shared-components/typography/index.js
+++ b/src/shared-components/typography/index.js
@@ -89,24 +89,30 @@ export const style =  {
   link: linkStyle,
 };
 
-const ButtonText = styled.span(buttonStyle);
+const Button = styled.span(buttonStyle);
 const Caption = styled.p(captionStyle);
 const Display = styled.h1(displayStyle);
-const ErrorText = styled.p(errorStyle);
+const ErrorComponent = styled.p(errorStyle);
 const Heading = styled.h2(headingStyle);
 const Label = styled.label(labelStyle);
-const LinkTag = styled.a(linkStyle);
-const SuccessText = styled.p(successStyle);
+const Link = styled.a(linkStyle);
+const Success = styled.p(successStyle);
 const Title = styled.h3(titleStyle);
 
 export default {
-  ButtonText,
+  Button,
   Caption,
   Display,
-  ErrorText,
+  Error: ErrorComponent,
   Heading,
   Label,
-  LinkTag,
-  SuccessText,
+  Link,
+  Success,
   Title,
+
+  // Legacy names. Will be removed in v2 (next major)
+  LinkTag: Link,
+  ButtonText: Button,
+  SuccessText: Success,
+  ErrorText: ErrorComponent,
 };

--- a/src/shared-components/typography/index.js
+++ b/src/shared-components/typography/index.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'react-emotion';
 import round from 'lodash.round';
 
+import { withDeprecationWarning } from '../../utils';
 import { COLORS, TYPOGRAPHY_CONSTANTS } from '../../constants';
 
 const displayStyle = css`
@@ -99,7 +100,7 @@ const Link = styled.a(linkStyle);
 const Success = styled.p(successStyle);
 const Title = styled.h3(titleStyle);
 
-export default {
+const Typography = {
   Button,
   Caption,
   Display,
@@ -116,3 +117,12 @@ export default {
   SuccessText: Success,
   ErrorText: ErrorComponent,
 };
+
+const deprecatedProperties = {
+  LinkTag: 'LinkTag will be deprecated in v2. Use Link instead',
+  ButtonText: 'ButtonText will be deprecated in v2. Use Button instead',
+  SuccessText: 'SuccessText will be deprecated in v2. Use Success instead',
+  ErrorText: 'ErrorText will be deprecated in v2. Use Error instead',
+};
+
+export default withDeprecationWarning(Typography, deprecatedProperties);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,3 @@
 export * from './colors';
 export { default as throwOnUndefinedProperty } from './throwOnUndefinedProperty';
+export { default as withDeprecationWarning } from './withDeprecationWarning';

--- a/src/utils/withDeprecationWarning/index.js
+++ b/src/utils/withDeprecationWarning/index.js
@@ -1,0 +1,13 @@
+export default function withDeprecationWarning(obj, deprecatedProperties = {}) {
+  const handler = {
+    get(target, property) {
+      if (Object.keys(deprecatedProperties).includes(property)) {
+        console.warn(`[Deprecation Warning]: ${deprecatedProperties[property]}`);
+      }
+
+      return target[property];
+    },
+  };
+
+  return new Proxy(obj, handler);
+}

--- a/src/utils/withDeprecationWarning/test.js
+++ b/src/utils/withDeprecationWarning/test.js
@@ -30,14 +30,14 @@ describe('property that is not in deprecatedProperties', () => {
 });
 
 describe('property that is in deprecatedProperties', () => {
-  test('does warns in console', () => {
+  test('warns in console', () => {
     const warn = jest.spyOn(console, 'warn');
     const subject = withDeprecationWarning(testObj, deprecatedProperties);
 
     // eslint-disable-next-line no-unused-expressions
     subject.deprecated
 
-    expect(warn).toHaveBeenCalledWith(`[Deprecation Warning] ${deprecatedMessage}`);
+    expect(warn).toHaveBeenCalledWith(`[Deprecation Warning]: ${deprecatedMessage}`);
     warn.mockRestore();
   });
 

--- a/src/utils/withDeprecationWarning/test.js
+++ b/src/utils/withDeprecationWarning/test.js
@@ -1,0 +1,50 @@
+import withDeprecationWarning from './index';
+
+const deprecatedMessage = 'This is deprecated!';
+const testObj = {
+  notDeprecated: 'foo',
+  deprecated: 'bar',
+};
+const deprecatedProperties = {
+  deprecated: deprecatedMessage,
+};
+
+describe('property that is not in deprecatedProperties', () => {
+  test('does not warn in console', () => {
+    const warn = jest.spyOn(console, 'warn');
+    const subject = withDeprecationWarning(testObj, deprecatedProperties);
+
+    // eslint-disable-next-line no-unused-expressions
+    subject.notDeprecated
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test('returns the property value', () => {
+    const subject = withDeprecationWarning(testObj, deprecatedProperties);
+    const value = subject.notDeprecated;
+
+    expect(value).toBe('foo');
+  });
+});
+
+describe('property that is in deprecatedProperties', () => {
+  test('does warns in console', () => {
+    const warn = jest.spyOn(console, 'warn');
+    const subject = withDeprecationWarning(testObj, deprecatedProperties);
+
+    // eslint-disable-next-line no-unused-expressions
+    subject.deprecated
+
+    expect(warn).toHaveBeenCalledWith(`[Deprecation Warning] ${deprecatedMessage}`);
+    warn.mockRestore();
+  });
+
+  test('returns the property value', () => {
+    const subject = withDeprecationWarning(testObj, deprecatedProperties);
+    const value = subject.deprecated;
+
+    expect(value).toBe('bar');
+  });
+});

--- a/stories/typography/index.js
+++ b/stories/typography/index.js
@@ -22,12 +22,12 @@ stories.add(
         <p>Body</p>
         <Typography.Caption>Caption</Typography.Caption>
         <Typography.Label>Label</Typography.Label>
-        <Typography.ErrorText>ErrorText</Typography.ErrorText>
-        <Typography.SuccessText>SuccessText</Typography.SuccessText>
+        <Typography.Error>Error</Typography.Error>
+        <Typography.Success>Success</Typography.Success>
         <div>
-          <Typography.LinkTag>LinkTag</Typography.LinkTag>
+          <Typography.Link>Link</Typography.Link>
         </div>
-        <Typography.ButtonText>ButtonText</Typography.ButtonText>
+        <Typography.Button>Button</Typography.Button>
       </div>
       <div css={`text-align: left; padding-top: ${SPACING.small};`}>
         <Typography.Heading>With Knobs</Typography.Heading>


### PR DESCRIPTION
Chatted with @benkolde regarding the naming and making it consistent.

Before, we were importing the typography components at the top level:
```jsx
import { ErrorText } from 'shared-components\typography';

<ErrorText>Error Message!</ErrorText>
```

However, now it's namespaced so we have more context AND we won't run into name collision issues
```jsx
import { Typography } from 'radiance-ui';

<Typography.Error>Error Message!</Typography.Error>
```

Also took care to not make any breaking changes until a major release version. Aka:
- Removed old usage from documentation but kept it in the code
- Added note to remove for next major