### PR TITLE
move breakpoints into its own constant file

### DIFF
--- a/src/constants/breakpoints/index.js
+++ b/src/constants/breakpoints/index.js
@@ -1,0 +1,10 @@
+import { throwOnUndefinedProperty } from '../../utils';
+
+export default throwOnUndefinedProperty({
+  xs: 330,
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200,
+  xxl: 1440,
+});

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,6 @@
 export { default as ANIMATION } from './animation';
 export { default as BOX_SHADOWS } from './boxShadows';
+export { default as BREAKPOINTS } from './breakpoints';
 export { default as COLORS } from './colors';
 export { default as FONTS } from './fonts';
 export { default as GRID } from './grid';

--- a/src/constants/mediaQueries/index.js
+++ b/src/constants/mediaQueries/index.js
@@ -1,13 +1,5 @@
 import { throwOnUndefinedProperty } from '../../utils';
-
-export const BREAKPOINTS = {
-  xs: 330,
-  sm: 576,
-  md: 768,
-  lg: 992,
-  xl: 1200,
-  xxl: 1440,
-};
+import BREAKPOINTS from '../breakpoints';
 
 const mediaQueries = Object.entries(BREAKPOINTS).reduce(
   (accumulator, [label, px]) => ({


### PR DESCRIPTION
Didn't notice the breakpoints inside of the MEDIA_QUERIES constant was being exported and used in our main repo. This puts breakpoints in its own constant file so it's easier to import

Storybook automagically updated:
<img width="1330" alt="screen shot 2018-10-30 at 4 29 54 pm" src="https://user-images.githubusercontent.com/9381931/47756888-0e9e6480-dc61-11e8-9420-65609e849b5c.png">
