### PR TITLE
Fix icon loading on Storybook + add readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ typings/
 dist/
 lib/
 .out
+.size-snapshot.json

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -11,10 +11,11 @@ module.exports = {
       {
         test: /\.svg$/,
         loader: 'file-loader',
+        include: [path.resolve(__dirname, '..')],
         options: {
-          name: '[name].[ext]'
+          name: '[name].[ext]',
         }
-      }
+      },
     ],
   },
   plugins: [
@@ -25,6 +26,6 @@ module.exports = {
       allowAsyncCycles: false,
       // set the current working directory for displaying module paths
       cwd: process.cwd(),
-    })
-  ]
+    }),
+  ],
 };

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Curology's React based component library
 
 ## Storybook
 Radiance UI has a built in storybook. Every time a new commit is made to
-mastter, it is automatically deployed to
+master, it is automatically deployed to
 [https://radiance-ui.curology.com](https://radiance-ui.curology.com).
 
 To run Storybook locally, use `yarn run storybook`.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,27 @@
 [ ![Codeship Status for PocketDerm/radiance-ui](https://app.codeship.com/projects/b14c5140-badd-0136-4a26-6e82e5b69006/status?branch=master)](https://app.codeship.com/projects/312533)
 
 Curology's React based component library
+
+## Storybook
+Radiance UI has a built in storybook. Every time a new commit is made to
+mastter, it is automatically deployed to
+[https://curology-radiance.herokupapp.com](https://curology-radiance.herokuapp.com).
+
+To run Storybook locally, use `yarn run storybook`.
+
+## Contributing
+To contribute to Radiance UI, please create a PR with the following in
+the appropriate places:
+
+- Source code for the component
+- Tests
+- A storybook story
+
+## Tests
+Tests can be run with `yarn run test`. Radiance uses Jest + Enzyme.
+
+
+## Local Development Setup
+If you want to test out your changes with another repo that uses
+Radiance, we recommend using the `link` feature with [npm](https://docs.npmjs.com/cli/link)
+or [yarn](https://yarnpkg.com/lang/en/docs/cli/link/).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Curology's React based component library
 ## Storybook
 Radiance UI has a built in storybook. Every time a new commit is made to
 mastter, it is automatically deployed to
-[https://curology-radiance.herokupapp.com](https://curology-radiance.herokuapp.com).
+[https://radiance-ui.curology.com](https://radiance-ui.curology.com).
 
 To run Storybook locally, use `yarn run storybook`.
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,6 @@ module.exports = {
   ],
   plugins: [
     'emotion',
-    'transform-svg-import-to-string',
     '@babel/plugin-proposal-export-namespace-from',
     ['@babel/plugin-proposal-class-properties', { 'loose': true }],
     ['@babel/plugin-transform-parameters', { 'loose': true }],

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-size-snapshot": "^0.7.0",
+    "rollup-plugin-url": "^2.0.1",
     "storybook-readme": "^4.0.2",
     "tinycolor2": "^1.4.1",
     "webpack": "^4.23.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
+    "file-loader": "^2.0.0",
     "husky": "^1.1.2",
     "jest": "^23.6.0",
     "lint-staged": "^7.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,8 @@
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
+import { sizeSnapshot } from "rollup-plugin-size-snapshot";
+import url from "rollup-plugin-url"
 
 const path = require('path');
 
@@ -27,6 +29,7 @@ export default {
     },
   ],
   plugins: [
+    url(),
     resolve({
       customResolveOptions: {
         moduleDirectory: [path.resolve(__dirname, '.'), 'node_modules'],
@@ -36,6 +39,7 @@ export default {
       include: 'node_modules/**',
     }),
     babel(),
+    sizeSnapshot(),
   ],
   external: [
     'emotion',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,7 +2491,7 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bytes@3.0.0:
+bytes@3.0.0, bytes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
@@ -4744,7 +4744,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gzip-size@5.0.0:
+gzip-size@5.0.0, gzip-size@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
   integrity sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==
@@ -6506,7 +6506,7 @@ memory-fs@^0.2.0:
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
   integrity sha1-8rslNovBIeORwlIN6Slpyu4KApA=
 
-memory-fs@^0.4.0, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
@@ -6707,6 +6707,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-1.0.0.tgz#ebb3a977e7af1c683ae6fda12b545a6ba6c5853d"
+  integrity sha1-67Opd+evHGg65v2hK1Raa6bFhT0=
 
 moo@^0.4.3:
   version "0.4.3"
@@ -8542,7 +8547,40 @@ rollup-plugin-node-resolve@^3.4.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
-rollup-pluginutils@^2.3.0, rollup-pluginutils@^2.3.3:
+rollup-plugin-replace@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.1.0.tgz#f9c07a4a89a2f8be912ee54b3f0f68d91e9ed0ae"
+  integrity sha512-SxrAIgpH/B5/W4SeULgreOemxcpEgKs2gcD42zXw50bhqGWmcnlXneVInQpAqzA/cIly4bJrOpeelmB9p4YXSQ==
+  dependencies:
+    magic-string "^0.25.1"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-size-snapshot@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-size-snapshot/-/rollup-plugin-size-snapshot-0.7.0.tgz#f0070e4aeee736f45f8eb6b96e12e6238705c13b"
+  integrity sha512-wlFRHInOfJZbXHWA4rftymqHuVDCeKUhJF3vuBZuU5y+O0LAj6RQM7vGn2/UoLImENFci31ff3pnKjW36DDP2A==
+  dependencies:
+    acorn "^6.0.1"
+    bytes "^3.0.0"
+    chalk "^2.4.1"
+    gzip-size "^5.0.0"
+    jest-diff "^23.6.0"
+    memory-fs "^0.4.1"
+    rollup-plugin-replace "^2.0.0"
+    terser "^3.8.2"
+    webpack "^4.19.0"
+
+rollup-plugin-url@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-url/-/rollup-plugin-url-2.0.1.tgz#d6481321e05196c37a48ac576a07ff212dd02742"
+  integrity sha512-MEl76wFtH3DE1ETxac5/TUNKW4lRxqx9wmWK49xLluhr9CIV3p3zs8Rtg6BYm1LyIf3pyh+SmXaQ6ikiDHd4kA==
+  dependencies:
+    mime "^2.3.1"
+    mkpath "^1.0.0"
+    rollup-pluginutils "^2.3.3"
+
+rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.0, rollup-pluginutils@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"
   integrity sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==
@@ -8906,7 +8944,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@^0.5.9:
+source-map-support@^0.5.6, source-map-support@^0.5.9, source-map-support@~0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
@@ -9323,6 +9361,15 @@ term-size@^1.2.0:
   integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
   dependencies:
     execa "^0.7.0"
+
+terser@^3.8.2:
+  version "3.10.11"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.10.11.tgz#e063da74b194dde9faf0a561f3a438c549d2da3f"
+  integrity sha512-iruZ7j14oBbRYJC5cP0/vTU7YOWjN+J1ZskEGoF78tFzXdkK2hbCL/3TRZN8XB+MuvFhvOHMp7WkOCBO4VEL5g==
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
+    source-map-support "~0.5.6"
 
 test-exclude@^4.2.1:
   version "4.2.3"
@@ -9817,6 +9864,36 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack@^4.19.0:
+  version "4.25.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.25.1.tgz#4f459fbaea0f93440dc86c89f771bb3a837cfb6d"
+  integrity sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-module-context" "1.7.11"
+    "@webassemblyjs/wasm-edit" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.1.0"
+    uglifyjs-webpack-plugin "^1.2.4"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
 
 webpack@^4.23.0, webpack@^4.23.1:
   version "4.24.0"


### PR DESCRIPTION
There were some issues on loading icons in storybook. This fixes the issue by removing `transform-svg-import-to-string` from babel config and adding a new rollup plugin that allows the ESM output to be compiled correctly without the babel plugin.