### PR TITLE
Adding in documentation links into the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Radiance, we recommend using the `link` feature with [npm](https://docs.npmjs.co
 or [yarn](https://yarnpkg.com/lang/en/docs/cli/link/).
 
 ## Documentation
-Documentation around usage
+Documentation around usage, you can also see it with knobs at: [https://radiance-ui.curology.com](https://radiance-ui.curology.com)
 - [Alert](docs/alert.md)
 - [Constants](docs/constants.md)
 - [Icon](docs/icon.md)

--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ Tests can be run with `yarn run test`. Radiance uses Jest + Enzyme.
 If you want to test out your changes with another repo that uses
 Radiance, we recommend using the `link` feature with [npm](https://docs.npmjs.com/cli/link)
 or [yarn](https://yarnpkg.com/lang/en/docs/cli/link/).
+
+## Documentation
+Documentation around usage
+- [Alert](docs/alert.md)
+- [Constants](docs/constants.md)
+- [Icon](docs/icon.md)
+- [Typography](docs/typography.md)
+- [Typography Style](docs/typography-style.md)


### PR DESCRIPTION
Adding links to the documentation from the main front-page readme so that it's more clear where the documentation is, and easier to access them as well.  Fixes #9 

