### PR TITLE
[Alerts] Prevent calling exit multiple times

### DIFF
--- a/src/shared-components/alert/index.js
+++ b/src/shared-components/alert/index.js
@@ -58,6 +58,9 @@ class Alert extends React.Component {
     this.setState({ exiting: true });
 
     // eslint-disable-next-line no-undef
+    window.clearTimeout(this.timer);
+
+    // eslint-disable-next-line no-undef
     window.setTimeout(() => {
       onExit({...rest});
       this.setState({exited: true });


### PR DESCRIPTION
`exit` function can be called from the duration expiration or onClick of the alert component. This prevents the `exit` function being called twice if onClick happens immediately right before the duration expires.