### PR TITLE
add quinary button

### DIFF
--- a/docs/button.md
+++ b/docs/button.md
@@ -11,9 +11,6 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button buttonType="secondary">Secondary Button</Button>
     <Button buttonType="tertiary">Tertiary Button</Button>
     <Button buttonType="quaternary">Quaternary Button</Button>
-    <div css="background-color: lavender">
-      <Button buttonType="quinary">Quinary Button</Button>
-    </div>
     <Button disabled>Disabled Button</Button>
 
     <Button loading>Primary Loading</Button>
@@ -26,11 +23,6 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button buttonType="quaternary" loading>
       Quaternary Loading
     </Button>
-    <div css="background-color: lavender">
-      <Button buttonType="quinary" loading>
-        Quinary Loading
-      </Button>
-    </div>
   </Button.Container>
 
   <Button.Container>
@@ -44,11 +36,6 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button buttonType="quaternary" icon={<CheckmarkIcon />}>
       Quaternary Button
     </Button>
-    <div css="background-color: lavender">
-      <Button buttonType="quinary" icon={<CheckmarkIcon />}>
-        Quinary Button
-      </Button>
-    </div>
 
     <Button disabled icon={<CheckmarkIcon />}>
       Disabled Button
@@ -65,11 +52,6 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button loading buttonType="quaternary" icon={<CheckmarkIcon />}>
       Quaternary Loading
     </Button>
-    <div css="background-color: lavender">
-      <Button loading buttonType="quinary" icon={<CheckmarkIcon />}>
-        Quinary Loading
-      </Button>
-    </div>
   </Button.Container>
 </React.Fragment>
 ```
@@ -79,12 +61,13 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
 ### Proptypes
 | prop     | propType           | required | default | description                                                                                                                  |
 |----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`, `quinary`. |
+| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`. |
 | children | node | yes | - | node to be rendered inside the button.  Recommended to be the button text |
 | disabled | bool               | no       | false   | when disabled, click listener will not be called and the UI will look disabled |
 | icon | node | no | null | icon to render in the button. Recommended to use one of Radiance's icons |
 | loading  | bool               | no       | false   | renders loading state and prevents click listener from being called |
 | onClick   | func              | no      | () => {} | callback function called on click of the button |
+| textColor | string | no | '' | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
 
 ### Notes
 Buttons can be used as a main call-to-action (CTA). Try to avoid using

--- a/docs/button.md
+++ b/docs/button.md
@@ -11,7 +11,11 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button buttonType="secondary">Secondary Button</Button>
     <Button buttonType="tertiary">Tertiary Button</Button>
     <Button buttonType="quaternary">Quaternary Button</Button>
+    <div css="background-color: lavender">
+      <Button buttonType="quinary">Quinary Button</Button>
+    </div>
     <Button disabled>Disabled Button</Button>
+
     <Button loading>Primary Loading</Button>
     <Button loading buttonType="secondary">
       Secondary Loading
@@ -22,6 +26,11 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button buttonType="quaternary" loading>
       Quaternary Loading
     </Button>
+    <div css="background-color: lavender">
+      <Button buttonType="quinary" loading>
+        Quinary Loading
+      </Button>
+    </div>
   </Button.Container>
 
   <Button.Container>
@@ -32,10 +41,14 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button buttonType="tertiary" icon={<CheckmarkIcon />}>
       Tertiary Button
     </Button>
-
     <Button buttonType="quaternary" icon={<CheckmarkIcon />}>
       Quaternary Button
     </Button>
+    <div css="background-color: lavender">
+      <Button buttonType="quinary" icon={<CheckmarkIcon />}>
+        Quinary Button
+      </Button>
+    </div>
 
     <Button disabled icon={<CheckmarkIcon />}>
       Disabled Button
@@ -49,10 +62,14 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button loading buttonType="tertiary" icon={<CheckmarkIcon />}>
       Tertiary Loading
     </Button>
-
     <Button loading buttonType="quaternary" icon={<CheckmarkIcon />}>
       Quaternary Loading
     </Button>
+    <div css="background-color: lavender">
+      <Button loading buttonType="quinary" icon={<CheckmarkIcon />}>
+        Quinary Loading
+      </Button>
+    </div>
   </Button.Container>
 </React.Fragment>
 ```
@@ -62,7 +79,7 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
 ### Proptypes
 | prop     | propType           | required | default | description                                                                                                                  |
 |----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`. |
+| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`, `quinary`. |
 | children | node | yes | - | node to be rendered inside the button.  Recommended to be the button text |
 | disabled | bool               | no       | false   | when disabled, click listener will not be called and the UI will look disabled |
 | icon | node | no | null | icon to render in the button. Recommended to use one of Radiance's icons |

--- a/docs/roundButton.md
+++ b/docs/roundButton.md
@@ -66,6 +66,7 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
 | icon | node | yes | null | icon to render in the button. Recommended to use one of Radiance's icons |
 | loading  | bool               | no       | false   | renders loading state and prevents click listener from being called |
 | onClick   | func              | no      | () => {} | callback function called on click of the button |
+| textColor | string | no | '' | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
 
 ### Notes
 `<RoundButton />` behaves mostly the same as `<Button />` except that it

--- a/docs/roundButton.md
+++ b/docs/roundButton.md
@@ -20,11 +20,6 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
       Quaternary
     </RoundButton>
   </RoundButton.Container>
-  <RoundButton.Container multi css="background-color: lavender">
-    <RoundButton buttonType="quinary" icon={<CheckmarkIcon />}>
-      Quinary
-    </RoundButton>
-  </RoundButton.Container>
   <RoundButton.Container multi>
     <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} disabled>
       Disabled
@@ -47,11 +42,6 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
       Quaternary Loading
     </RoundButton>
   </RoundButton.Container>
-  <RoundButton.Container multi css="background-color: lavender">
-    <RoundButton buttonType="quinary" icon={<ArrowLeftIcon />} loading>
-      Quinary Loading
-    </RoundButton>
-  </RoundButton.Container>
 </React.Fragment>
 ```
 
@@ -60,7 +50,7 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
 ### Proptypes
 | prop     | propType           | required | default | description                                                                                                                  |
 |----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`, `quinary`. |
+| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`. |
 | children | node | yes | - | node to be rendered inside the button.  Recommended to be the button text |
 | disabled | bool               | no       | false   | when disabled, click listener will not be called and the UI will look disabled |
 | icon | node | yes | null | icon to render in the button. Recommended to use one of Radiance's icons |

--- a/docs/roundButton.md
+++ b/docs/roundButton.md
@@ -20,11 +20,17 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
       Quaternary
     </RoundButton>
   </RoundButton.Container>
+  <RoundButton.Container multi css="background-color: lavender">
+    <RoundButton buttonType="quinary" icon={<CheckmarkIcon />}>
+      Quinary
+    </RoundButton>
+  </RoundButton.Container>
   <RoundButton.Container multi>
     <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} disabled>
       Disabled
     </RoundButton>
   </RoundButton.Container>
+
   <RoundButton.Container multi>
     <RoundButton icon={<ArrowLeftIcon />} loading>
       Primary Loading
@@ -41,6 +47,11 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
       Quaternary Loading
     </RoundButton>
   </RoundButton.Container>
+  <RoundButton.Container multi css="background-color: lavender">
+    <RoundButton buttonType="quinary" icon={<ArrowLeftIcon />} loading>
+      Quinary Loading
+    </RoundButton>
+  </RoundButton.Container>
 </React.Fragment>
 ```
 
@@ -49,7 +60,7 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
 ### Proptypes
 | prop     | propType           | required | default | description                                                                                                                  |
 |----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`. |
+| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`, `quinary`. |
 | children | node | yes | - | node to be rendered inside the button.  Recommended to be the button text |
 | disabled | bool               | no       | false   | when disabled, click listener will not be called and the UI will look disabled |
 | icon | node | yes | null | icon to render in the button. Recommended to use one of Radiance's icons |

--- a/src/shared-components/accordion/index.js
+++ b/src/shared-components/accordion/index.js
@@ -31,13 +31,13 @@ class Accordion extends React.Component {
     disabled: false,
   };
 
-  static Container = ({ children }) => <Container>{children}</Container>;
+  static Container = Container;
 
-  static Content = ({ children }) => <Content>{children}</Content>;
+  static Content = Content;
 
-  static Thumbnails = ({ photoSrcs }) => <Thumbnails photoSrcs={photoSrcs} />;
+  static Thumbnails = Thumbnails;
 
-  static Truncate = ({ children }) => <Truncate>{children}</Truncate>;
+  static Truncate = Truncate;
 
   contentRef = React.createRef();
 

--- a/src/shared-components/button/components/roundButton/index.js
+++ b/src/shared-components/button/components/roundButton/index.js
@@ -19,10 +19,10 @@ const propTypes = {
     'secondary',
     'tertiary',
     'quaternary',
-    'quinary',
   ]),
   loading: PropTypes.bool,
   icon: PropTypes.node.isRequired,
+  textColor: PropTypes.string,
 };
 
 const defaultProps = {
@@ -31,6 +31,7 @@ const defaultProps = {
   loading: false,
   onClick() {},
   children: '',
+  textColor: '',
 };
 
 const RoundButton = ({
@@ -40,6 +41,7 @@ const RoundButton = ({
   buttonType,
   loading,
   icon,
+  textColor,
   ...rest
 }) => (
   <RoundButtonWrapper
@@ -52,6 +54,7 @@ const RoundButton = ({
       buttonType={buttonType}
       loading={loading}
       type="button"
+      textColor={textColor}
       {...rest}
     >
       {icon}
@@ -60,6 +63,7 @@ const RoundButton = ({
         disabled={disabled}
         buttonType={buttonType}
         className={roundButtonLoader(disabled)}
+        textColor={textColor}
       />
     </RoundButtonBase>
     {children && <RoundButtonText>{children}</RoundButtonText>}

--- a/src/shared-components/button/components/roundButton/index.js
+++ b/src/shared-components/button/components/roundButton/index.js
@@ -14,7 +14,13 @@ const propTypes = {
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   children: PropTypes.node,
-  buttonType: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'quaternary']),
+  buttonType: PropTypes.oneOf([
+    'primary',
+    'secondary',
+    'tertiary',
+    'quaternary',
+    'quinary',
+  ]),
   loading: PropTypes.bool,
   icon: PropTypes.node.isRequired,
 };

--- a/src/shared-components/button/index.js
+++ b/src/shared-components/button/index.js
@@ -17,6 +17,7 @@ class Button extends React.Component {
       'secondary',
       'tertiary',
       'quaternary',
+      'quinary',
     ]),
     loading: PropTypes.bool,
     icon: PropTypes.node,

--- a/src/shared-components/button/index.js
+++ b/src/shared-components/button/index.js
@@ -17,10 +17,10 @@ class Button extends React.Component {
       'secondary',
       'tertiary',
       'quaternary',
-      'quinary',
     ]),
     loading: PropTypes.bool,
     icon: PropTypes.node,
+    textColor: PropTypes.string,
   };
 
   static defaultProps = {
@@ -28,6 +28,7 @@ class Button extends React.Component {
     buttonType: 'primary',
     loading: false,
     onClick() {},
+    textColor: '',
   };
 
   render() {
@@ -38,6 +39,7 @@ class Button extends React.Component {
       buttonType,
       loading,
       icon,
+      textColor,
       ...rest
     } = this.props;
 
@@ -48,6 +50,7 @@ class Button extends React.Component {
         buttonType={buttonType}
         loading={loading}
         type="button"
+        textColor={textColor}
         {...rest}
       >
         <ButtonContents loading={loading} hasIcon={!!icon}>
@@ -64,6 +67,7 @@ class Button extends React.Component {
           loading={loading}
           disabled={disabled}
           buttonType={buttonType}
+          textColor={textColor}
         />
       </ButtonBase>
     );

--- a/src/shared-components/button/shared-components/loader/index.js
+++ b/src/shared-components/button/shared-components/loader/index.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 
 import ButtonLoader from './style';
 
-const Loader = ({loading, disabled, buttonType, className}) => (
+const Loader = ({loading, disabled, buttonType, className, textColor }) => (
   <ButtonLoader
     loading={loading}
     disabled={disabled}
     buttonType={buttonType}
     className={className}
+    textColor={textColor}
   >
     <div>
       <span />
@@ -26,9 +27,9 @@ Loader.propTypes = {
     'secondary',
     'tertiary',
     'quaternary',
-    'quinary',
   ]),
   className: PropTypes.string,
+  textColor: PropTypes.string,
 };
 
 export default Loader;

--- a/src/shared-components/button/shared-components/loader/index.js
+++ b/src/shared-components/button/shared-components/loader/index.js
@@ -26,6 +26,7 @@ Loader.propTypes = {
     'secondary',
     'tertiary',
     'quaternary',
+    'quinary',
   ]),
   className: PropTypes.string,
 };

--- a/src/shared-components/button/shared-components/loader/style.js
+++ b/src/shared-components/button/shared-components/loader/style.js
@@ -52,7 +52,7 @@ const ButtonLoader = styled.div`
   }};
 
     ${({ textColor, disabled }) => !!textColor && !disabled && `
-      background-color: ${textColor}
+      background-color: ${textColor};
     `}
 
     border-radius: 50%;

--- a/src/shared-components/button/shared-components/loader/style.js
+++ b/src/shared-components/button/shared-components/loader/style.js
@@ -51,6 +51,10 @@ const ButtonLoader = styled.div`
     }
   }};
 
+    ${({ textColor, disabled }) => !!textColor && !disabled && `
+      background-color: ${textColor}
+    `}
+
     border-radius: 50%;
     display: inline-block;
     height: 4px;

--- a/src/shared-components/button/style.js
+++ b/src/shared-components/button/style.js
@@ -58,6 +58,18 @@ const quaternaryStyles = css`
   }
 `;
 
+const quinaryStyles = css`
+  border-color: transparent;
+  background-color: transparent;
+  color: ${COLORS.white};
+  fill: ${COLORS.white};
+
+  &:hover {
+    opacity: 0.8;
+    background-color: transparent;
+  }
+`;
+
 const loadingStyles = css`
   cursor: not-allowed;
 
@@ -92,6 +104,8 @@ function parseTheme(disabled, buttonType, loading) {
       return tertiaryStyles;
     case 'quaternary':
       return quaternaryStyles;
+    case 'quinary':
+      return quinaryStyles;
     default:
       return primaryStyles;
   }

--- a/src/shared-components/button/style.js
+++ b/src/shared-components/button/style.js
@@ -58,18 +58,6 @@ const quaternaryStyles = css`
   }
 `;
 
-const quinaryStyles = css`
-  border-color: transparent;
-  background-color: transparent;
-  color: ${COLORS.white};
-  fill: ${COLORS.white};
-
-  &:hover {
-    opacity: 0.8;
-    background-color: transparent;
-  }
-`;
-
 const loadingStyles = css`
   cursor: not-allowed;
 
@@ -104,14 +92,12 @@ function parseTheme(disabled, buttonType, loading) {
       return tertiaryStyles;
     case 'quaternary':
       return quaternaryStyles;
-    case 'quinary':
-      return quinaryStyles;
     default:
       return primaryStyles;
   }
 }
 
-const baseButtonStyles = ({ disabled, buttonType, loading }) => css`
+const baseButtonStyles = ({ disabled, buttonType, loading, textColor }) => css`
   ${TYPOGRAPHY_STYLE.button};
   appearance: none;
   border-radius: 0;
@@ -141,6 +127,11 @@ const baseButtonStyles = ({ disabled, buttonType, loading }) => css`
 
   ${parseTheme(disabled, buttonType, loading)};
   ${loading && loadingStyles};
+
+  ${!!textColor && !disabled && `
+    color: ${textColor};
+    fill: ${textColor};
+  `}
 `;
 
 export const ButtonBase = styled.button(baseButtonStyles);

--- a/stories/button/index.js
+++ b/stories/button/index.js
@@ -26,9 +26,6 @@ stories.add(
         <Button buttonType="secondary">Secondary Button</Button>
         <Button buttonType="tertiary">Tertiary Button</Button>
         <Button buttonType="quaternary">Quaternary Button</Button>
-        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
-          <Button buttonType="quinary">Quinary Button</Button>
-        </div>
         <Button disabled>Disabled Button</Button>
 
         <Button loading>Primary Loading</Button>
@@ -41,11 +38,6 @@ stories.add(
         <Button buttonType="quaternary" loading>
           Quaternary Loading
         </Button>
-        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
-          <Button buttonType="quinary" loading>
-            Quinary Loading
-          </Button>
-        </div>
       </Button.Container>
 
       <Button.Container css="width: 50%; display: inline-block;">
@@ -62,11 +54,6 @@ stories.add(
         <Button buttonType="quaternary" icon={<CheckmarkIcon />}>
           Quaternary Button
         </Button>
-        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
-          <Button buttonType="quinary" icon={<CheckmarkIcon />}>
-            Quinary Button
-          </Button>
-        </div>
         <Button disabled icon={<CheckmarkIcon />}>
           Disabled Button
         </Button>
@@ -83,21 +70,17 @@ stories.add(
         <Button loading buttonType="quaternary" icon={<CheckmarkIcon />}>
           Quaternary Loading
         </Button>
-        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
-          <Button loading buttonType="quinary" icon={<CheckmarkIcon />}>
-            Quinary Loading
-          </Button>
-        </div>
 
       </Button.Container>
       <Typography.Heading css={`text-align: left; padding: ${SPACING.base} 0 ${SPACING.small};`}>
         With Knobs
       </Typography.Heading>
       <Button
-        buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary', 'quinary'], 'primary')}
+        buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary'], 'primary')}
         loading={boolean('loading', false)}
         disabled={boolean('disabled', false)}
         onClick={action('button clicked')}
+        textColor={text('textColor', '')}
       >
         {text('children', 'Click me!')}
       </Button>
@@ -123,11 +106,6 @@ stories.add(
           Quaternary
         </RoundButton>
       </RoundButton.Container>
-      <RoundButton.Container multi css={`background-color: ${COLORS.lavender60};`}>
-        <RoundButton buttonType="quinary" icon={<CheckmarkIcon />}>
-          Quinary
-        </RoundButton>
-      </RoundButton.Container>
 
       <RoundButton.Container multi>
         <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} disabled>
@@ -150,22 +128,18 @@ stories.add(
           Quaternary Loading
         </RoundButton>
       </RoundButton.Container>
-      <RoundButton.Container multi css={`background-color: ${COLORS.lavender60};`}>
-        <RoundButton buttonType="quinary" icon={<ArrowLeftIcon />} loading>
-          Quinary Loading
-        </RoundButton>
-      </RoundButton.Container>
 
       <Typography.Heading css={`text-align: left; padding: ${SPACING.base} 0 ${SPACING.small};`}>
         With Knobs
       </Typography.Heading>
       <RoundButton.Container>
         <RoundButton
-          buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary', 'quinary'], 'primary')}
+          buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary'], 'primary')}
           loading={boolean('loading', false)}
           disabled={boolean('disabled', false)}
           onClick={action('button clicked')}
           icon={<CheckmarkIcon />}
+          textColor={text('textColor', '')}
         >
           {text('children', 'Click me!')}
         </RoundButton>

--- a/stories/button/index.js
+++ b/stories/button/index.js
@@ -6,9 +6,9 @@ import { action } from '@storybook/addon-actions';
 
 import ButtonReadme from 'docs/button.md';
 import RoundButtonReadme from 'docs/roundButton.md';
-import { CheckmarkIcon, ArrowLeftIcon, ArrowRightIcon } from 'src/icons';
+import { CheckmarkIcon, ArrowLeftIcon, ArrowRightIcon } from 'src/svgs/icons';
 import { Button, RoundButton, Typography } from 'src/shared-components';
-import { SPACING } from 'src/constants';
+import { SPACING, COLORS } from 'src/constants';
 
 const stories = storiesOf('Buttons', module);
 
@@ -26,7 +26,11 @@ stories.add(
         <Button buttonType="secondary">Secondary Button</Button>
         <Button buttonType="tertiary">Tertiary Button</Button>
         <Button buttonType="quaternary">Quaternary Button</Button>
+        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
+          <Button buttonType="quinary">Quinary Button</Button>
+        </div>
         <Button disabled>Disabled Button</Button>
+
         <Button loading>Primary Loading</Button>
         <Button loading buttonType="secondary">
           Secondary Loading
@@ -37,7 +41,13 @@ stories.add(
         <Button buttonType="quaternary" loading>
           Quaternary Loading
         </Button>
+        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
+          <Button buttonType="quinary" loading>
+            Quinary Loading
+          </Button>
+        </div>
       </Button.Container>
+
       <Button.Container css="width: 50%; display: inline-block;">
         <Typography.Heading css={`text-align: left; padding: ${SPACING.base} 0 ${SPACING.small};`}>
           With Icon
@@ -49,14 +59,18 @@ stories.add(
         <Button buttonType="tertiary" icon={<CheckmarkIcon />}>
           Tertiary Button
         </Button>
-
         <Button buttonType="quaternary" icon={<CheckmarkIcon />}>
           Quaternary Button
         </Button>
-
+        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
+          <Button buttonType="quinary" icon={<CheckmarkIcon />}>
+            Quinary Button
+          </Button>
+        </div>
         <Button disabled icon={<CheckmarkIcon />}>
           Disabled Button
         </Button>
+
         <Button loading icon={<CheckmarkIcon />}>
           Primary Loading
         </Button>
@@ -66,16 +80,21 @@ stories.add(
         <Button loading buttonType="tertiary" icon={<CheckmarkIcon />}>
           Tertiary Loading
         </Button>
-
         <Button loading buttonType="quaternary" icon={<CheckmarkIcon />}>
           Quaternary Loading
         </Button>
+        <div css={`width 100%; background-color: ${COLORS.lavender60};`}>
+          <Button loading buttonType="quinary" icon={<CheckmarkIcon />}>
+            Quinary Loading
+          </Button>
+        </div>
+
       </Button.Container>
       <Typography.Heading css={`text-align: left; padding: ${SPACING.base} 0 ${SPACING.small};`}>
         With Knobs
       </Typography.Heading>
       <Button
-        buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary'], 'primary')}
+        buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary', 'quinary'], 'primary')}
         loading={boolean('loading', false)}
         disabled={boolean('disabled', false)}
         onClick={action('button clicked')}
@@ -104,6 +123,12 @@ stories.add(
           Quaternary
         </RoundButton>
       </RoundButton.Container>
+      <RoundButton.Container multi css={`background-color: ${COLORS.lavender60};`}>
+        <RoundButton buttonType="quinary" icon={<CheckmarkIcon />}>
+          Quinary
+        </RoundButton>
+      </RoundButton.Container>
+
       <RoundButton.Container multi>
         <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} disabled>
           Disabled
@@ -125,12 +150,18 @@ stories.add(
           Quaternary Loading
         </RoundButton>
       </RoundButton.Container>
+      <RoundButton.Container multi css={`background-color: ${COLORS.lavender60};`}>
+        <RoundButton buttonType="quinary" icon={<ArrowLeftIcon />} loading>
+          Quinary Loading
+        </RoundButton>
+      </RoundButton.Container>
+
       <Typography.Heading css={`text-align: left; padding: ${SPACING.base} 0 ${SPACING.small};`}>
         With Knobs
       </Typography.Heading>
       <RoundButton.Container>
         <RoundButton
-          buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary'], 'primary')}
+          buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary', 'quinary'], 'primary')}
           loading={boolean('loading', false)}
           disabled={boolean('disabled', false)}
           onClick={action('button clicked')}


### PR DESCRIPTION
### What & Why
- Add Quinary button 
- Updated Button and Round Button stories

I also fixed the dot notation for the subcomponents in Accordion. 

<img width="778" alt="screen shot 2019-01-11 at 2 20 43 pm" src="https://user-images.githubusercontent.com/25893608/51062570-2e7ccd80-15ac-11e9-8466-c07261843f1c.png">

Needed for welcome page design:
<img width="385" alt="screen shot 2019-01-11 at 2 22 38 pm" src="https://user-images.githubusercontent.com/25893608/51062617-6126c600-15ac-11e9-8be3-0d1804338703.png">
