### PR TITLE
Modal gatsby patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiance-ui",
-  "version": "1.0.20",
+  "version": "2.0.0",
   "description": "Curology's React based component library",
   "main": "dist/bundle.js",
   "module": "dist/bundle.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiance-ui",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Curology's React based component library",
   "main": "dist/bundle.js",
   "module": "dist/bundle.es.js",

--- a/src/shared-components/modal/index.js
+++ b/src/shared-components/modal/index.js
@@ -16,11 +16,6 @@ import {
   Footer,
 } from './style';
 
-const el = document.querySelector('#reactPortalSection')
-  ? '#reactPortalSection'
-  : 'body';
-ReactModal.setAppElement(el);
-
 class Modal extends React.Component {
   static propTypes = {
     onClose: PropTypes.func,
@@ -50,6 +45,13 @@ class Modal extends React.Component {
     isVisible: false,
     parentNode: document.querySelector('#reactPortalSection') || document.body,
   };
+
+  componentWillMount() {
+    const el = document.querySelector('#reactPortalSection')
+      ? '#reactPortalSection'
+      : 'body';
+    ReactModal.setAppElement(el);
+  }
 
   componentDidMount() {
     document


### PR DESCRIPTION
In this PR
 - move reference to `document` inside of component to fix gatsby build error

Problem:
Getting build error on Gatsby b/c `document` is not defined at build-time on Heroku.

<img width="1242" alt="screen shot 2019-01-29 at 10 12 19 am" src="https://user-images.githubusercontent.com/25893608/51930524-abcb7f00-23af-11e9-9c39-a4f8fcf77d30.png">

Gatsby docs on issue -- they suggest moving the reference to `document` to a place that won't be called until `document` is defined:
https://www.gatsbyjs.org/docs/debugging-html-builds/

To fix this, moved the reference to the document inside the component so that `document` is defined by the time the reference is made.