### PR TITLE
Adjust immersive modal to take width param

### DIFF
--- a/docs/immersiveModal.md
+++ b/docs/immersiveModal.md
@@ -64,6 +64,23 @@ class DefaultImmersiveModal extends React.Component {
             </ImmersiveModal.Footer>
           </ImmersiveModal>
         )}
+        <br/>
+        <Button onClick={() => this.onOpenModal('medium')}>
+          Open medium width ImmersiveModal
+        </Button>
+        {mediumIsOpen && (
+          <ImmersiveModal onClose={this.onClose} width="medium">
+            <ImmersiveModal.Title>This is styled with ImmersiveModal.Title</ImmersiveModal.Title>
+            <ImmersiveModal.Body>This is styled with ImmersiveModal.Body.</ImmersiveModal.Body>
+            <ImmersiveModal.Footer>
+              This is styled with ImmersiveModal.Footer. It gives us a padding to separate
+              from the body.
+              <Button.Container>
+                <Button onClick={this.onClose}>Close ImmersiveModal</Button>
+              </Button.Container>
+            </ImmersiveModal.Footer>
+          </ImmersiveModal>
+        )}  
       </div>
     );
   }

--- a/src/shared-components/immersiveModal/index.js
+++ b/src/shared-components/immersiveModal/index.js
@@ -22,6 +22,7 @@ class ImmersiveModal extends React.Component {
     canBeClosed: PropTypes.bool,
     onClose: PropTypes.func,
     header: PropTypes.node,
+    width: PropTypes.oneOf(['small', 'medium'])
   };
 
   static defaultProps = {
@@ -74,11 +75,11 @@ class ImmersiveModal extends React.Component {
 
   render() {
     const {
-      children, canBeClosed, onClose, header, 
+      children, canBeClosed, onClose, header, width,
     } = this.props;
     return ReactDOM.createPortal(
       <Overlay>
-        <ModalContainer>
+        <ModalContainer width={width}>
           <OffClickWrapper onOffClick={this.closeModal}>
             {canBeClosed && (
               <CloseIconContainer onClick={onClose}>

--- a/src/shared-components/immersiveModal/index.js
+++ b/src/shared-components/immersiveModal/index.js
@@ -79,7 +79,7 @@ class ImmersiveModal extends React.Component {
     } = this.props;
     return ReactDOM.createPortal(
       <Overlay>
-        <ModalContainer width={width}>
+        <ModalContainer maxWidth={width}>
           <OffClickWrapper onOffClick={this.closeModal}>
             {canBeClosed && (
               <CloseIconContainer onClick={onClose}>

--- a/src/shared-components/immersiveModal/style.js
+++ b/src/shared-components/immersiveModal/style.js
@@ -25,13 +25,14 @@ export const ModalContainer = styled.div`
   background-color: ${COLORS.white};
   height: 100vh;
   margin: 0 auto;
-  max-width: ${({width}) => (width === 'medium' ? `${BREAKPOINTS.md}px` : `${BREAKPOINTS.sm}px`)}
+  max-width: ${BREAKPOINTS.sm}px;
   overflow-y: auto;
   position: relative;
   width: 100%;
 
-  ${MEDIA_QUERIES.smUp} {
+  ${MEDIA_QUERIES.mdUp} {
     height: auto;
+    max-width: ${({maxWidth}) => (maxWidth === 'medium' ? `${BREAKPOINTS.md}px` : `${BREAKPOINTS.sm}px`)};
     margin-bottom: ${SPACING.base};
     margin-top: ${SPACING.base};
   }

--- a/src/shared-components/immersiveModal/style.js
+++ b/src/shared-components/immersiveModal/style.js
@@ -25,7 +25,7 @@ export const ModalContainer = styled.div`
   background-color: ${COLORS.white};
   height: 100vh;
   margin: 0 auto;
-  max-width: ${BREAKPOINTS.sm}px;
+  max-width: ${({width}) => (width === 'medium' ? `${BREAKPOINTS.md}px` : `${BREAKPOINTS.sm}px`)}
   overflow-y: auto;
   position: relative;
   width: 100%;

--- a/src/shared-components/immersiveModal/style.js
+++ b/src/shared-components/immersiveModal/style.js
@@ -32,7 +32,7 @@ export const ModalContainer = styled.div`
 
   ${MEDIA_QUERIES.mdUp} {
     height: auto;
-    max-width: ${({maxWidth}) => (maxWidth === 'medium' ? `${BREAKPOINTS.md}px` : `${BREAKPOINTS.sm}px`)};
+    max-width: ${({maxWidth}) => (maxWidth === 'medium' ? `776px` : `${BREAKPOINTS.sm}px`)};
     margin-bottom: ${SPACING.base};
     margin-top: ${SPACING.base};
   }

--- a/stories/immersiveModal/defaultImmersiveModal.js
+++ b/stories/immersiveModal/defaultImmersiveModal.js
@@ -20,6 +20,7 @@ class DefaultImmersiveModal extends React.Component {
   state = {
     defaultIsOpen: false,
     headerIsOpen: false,
+    mediumIsOpen: false,
   };
 
   onOpenModal = modal => this.setState({ [`${modal}IsOpen`]: true });
@@ -27,10 +28,11 @@ class DefaultImmersiveModal extends React.Component {
   onClose = () => this.setState({
     defaultIsOpen: false,
     headerIsOpen: false,
+    mediumIsOpen: false,
   });
 
   render() {
-    const { defaultIsOpen, headerIsOpen } = this.state;
+    const { defaultIsOpen, headerIsOpen, mediumIsOpen} = this.state;
 
     return (
       <div>
@@ -68,6 +70,23 @@ class DefaultImmersiveModal extends React.Component {
             </ImmersiveModal.Footer>
           </ImmersiveModal>
         )}
+        <br/>
+        <Button onClick={() => this.onOpenModal('medium')}>
+          Open medium width ImmersiveModal
+        </Button>
+        {mediumIsOpen && (
+          <ImmersiveModal onClose={this.onClose} width="medium">
+            <ImmersiveModal.Title>This is styled with ImmersiveModal.Title</ImmersiveModal.Title>
+            <ImmersiveModal.Body>This is styled with ImmersiveModal.Body.</ImmersiveModal.Body>
+            <ImmersiveModal.Footer>
+              This is styled with ImmersiveModal.Footer. It gives us a padding to separate
+              from the body.
+              <Button.Container>
+                <Button onClick={this.onClose}>Close ImmersiveModal</Button>
+              </Button.Container>
+            </ImmersiveModal.Footer>
+          </ImmersiveModal>
+        )}        
       </div>
     );
   }


### PR DESCRIPTION
For the Change Plan modal in the Cancellation flow, the width has been set to 776px to match the new grid:

![screen shot 2019-03-07 at 11 28 11 am](https://user-images.githubusercontent.com/3611/53983493-22088300-40cc-11e9-9646-2f9cd0a73d66.png)

But the current immersiveModal's width is set to `${BREAKPOINTS.sm}px` which is `576px`

This PR adjusts the ImmersiveModal to allow for a `width` parameter of `small` (default) or `medium` to be passed in, with the `medium` option setting the modal to be `776px` wide.