### PR TITLE
Add `<LinkButton>` to Radiance ✨

### DIFF
--- a/docs/linkButton.md
+++ b/docs/linkButton.md
@@ -19,6 +19,10 @@ import { LinkButton } from 'radiance-ui';
       Tertiary
     </LinkButton>
 
+    <LinkButton buttonType="quaternary" href="#">
+      Quaternary
+    </LinkButton>
+
     <LinkButton disabled href="#">
       I am Disabled
     </LinkButton>

--- a/docs/linkButton.md
+++ b/docs/linkButton.md
@@ -1,0 +1,60 @@
+# LinkButton
+
+### Usage
+
+```jsx
+import { LinkButton } from 'radiance-ui';
+
+<React.Fragment>
+  <LinkButton.Container>
+    <LinkButton href="#">
+        Primary
+    </LinkButton>
+
+    <LinkButton buttonType="secondary" href="#">
+      Secondary
+    </LinkButton>
+
+    <LinkButton buttonType="tertiary" href="#">
+      Tertiary
+    </LinkButton>
+
+    <LinkButton disabled href="#">
+      I am Disabled
+    </LinkButton>
+  </LinkButton.Container>
+</React.Fragment>;
+```
+
+#### React Router Link
+
+```jsx
+import { LinkButton } from 'radiance-ui';
+import { Link } from 'react-router';
+
+<LinkButton to="/somepath" renderedTag={Link}>
+  Router Link
+</LinkButton>;
+```
+
+<!-- STORY -->
+
+### Proptypes
+
+| prop        | propType        | required | default  | description                                                                                                                  |
+| ----------- | --------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| renderedTag | string, element | no       | "a"      | Specifies the tag be rendered.                                                                                               |
+| buttonType  | string          | no       | primary  | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`.                                 |
+| children    | node            | yes      | -        | node to be rendered inside the button. Recommended to be the button text                                                     |
+| disabled    | bool            | no       | false    | when disabled, click listener will not be called and the UI will look disabled                                               |
+| onClick     | func            | no       | () => {} | callback function called on click of the button                                                                              |
+| textColor   | string          | no       | ''       | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
+
+### Notes
+
+`LinkButton` will render a 'button-like' link for directing/linking to the path
+specified. This component can work with React Router's `Link`/`NavLink` by passing
+in the router component as a prop ---> `<LinkButton to='/path' renderedTag={Link}> ....`.
+
+`<LinkButton.Container>` can be used to provide spacing between multiple
+buttons and behavior on various screen sizes.

--- a/docs/linkButton.md
+++ b/docs/linkButton.md
@@ -8,7 +8,7 @@ import { LinkButton } from 'radiance-ui';
 <React.Fragment>
   <LinkButton.Container>
     <LinkButton href="#">
-        Primary
+      Primary
     </LinkButton>
 
     <LinkButton buttonType="secondary" href="#">
@@ -32,7 +32,7 @@ import { LinkButton } from 'radiance-ui';
 import { LinkButton } from 'radiance-ui';
 import { Link } from 'react-router';
 
-<LinkButton to="/somepath" renderedTag={Link}>
+<LinkButton to="/somepath" as={Link}>
   Router Link
 </LinkButton>;
 ```
@@ -41,20 +41,20 @@ import { Link } from 'react-router';
 
 ### Proptypes
 
-| prop        | propType        | required | default  | description                                                                                                                  |
-| ----------- | --------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| renderedTag | string, element | no       | "a"      | Specifies the tag be rendered.                                                                                               |
-| buttonType  | string          | no       | primary  | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`.                                 |
-| children    | node            | yes      | -        | node to be rendered inside the button. Recommended to be the button text                                                     |
-| disabled    | bool            | no       | false    | when disabled, click listener will not be called and the UI will look disabled                                               |
-| onClick     | func            | no       | () => {} | callback function called on click of the button                                                                              |
-| textColor   | string          | no       | ''       | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
+| prop       | propType        | required | default  | description                                                                                                                  |
+| ---------- | --------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| as         | string, element | no       | "a"      | Specifies the tag be rendered.                                                                                               |
+| buttonType | string          | no       | primary  | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`.                                 |
+| children   | node            | yes      | -        | node to be rendered inside the button. Recommended to be the button text                                                     |
+| disabled   | bool            | no       | false    | when disabled, click listener will not be called and the UI will look disabled                                               |
+| onClick    | func            | no       | () => {} | callback function called on click of the button                                                                              |
+| textColor  | string          | no       | ''       | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
 
 ### Notes
 
 `LinkButton` will render a 'button-like' link for directing/linking to the path
 specified. This component can work with React Router's `Link`/`NavLink` by passing
-in the router component as a prop ---> `<LinkButton to='/path' renderedTag={Link}> ....`.
+in the router component as a prop ---> `<LinkButton to='/path' as={Link}> ....`.
 
 `<LinkButton.Container>` can be used to provide spacing between multiple
 buttons and behavior on various screen sizes.

--- a/src/shared-components/button/components/linkButton/__snapshots__/test.js.snap
+++ b/src/shared-components/button/components/linkButton/__snapshots__/test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LinkButton/> UI snapshots renders with props 1`] = `
+.emotion-4 {
+  color: #5C5876;
+  font-size: 0.75rem;
+  line-height: 1.67;
+  font-weight: bold;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
+  border-style: solid;
+  border-width: 2px;
+  cursor: pointer;
+  display: block;
+  margin: 0;
+  max-width: 325px;
+  min-height: 52px;
+  min-width: 208px;
+  opacity: 1;
+  padding: 0 1.5rem;
+  position: relative;
+  -webkit-transition: all 350ms ease-in-out;
+  transition: all 350ms ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  background-color: #332e54;
+  border-color: #332e54;
+  color: #ffffff;
+  fill: #ffffff;
+}
+
+.emotion-4:hover {
+  -webkit-transition: all 350ms ease-in-out;
+  transition: all 350ms ease-in-out;
+}
+
+.emotion-4:active,
+.emotion-4:focus {
+  outline: none;
+}
+
+.emotion-4:visited,
+.emotion-4:hover {
+  opacity: 0.8;
+}
+
+.emotion-4:focus,
+.emotion-4:not([href]):not([tabindex]):hover,
+.emotion-4:not([href]):not([tabindex]):focus {
+  color: #ffffff;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 1rem 0;
+  -webkit-transition: -webkit-transform 350ms;
+  -webkit-transition: transform 350ms;
+  transition: transform 350ms;
+  width: 100%;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+}
+
+.emotion-2 > svg {
+  opacity: 1;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+  margin-right: 1rem;
+  margin-top: -5px;
+}
+
+.emotion-0 {
+  line-height: 1.5;
+  margin: 0;
+  padding-top: 2px;
+}
+
+<a
+  className="emotion-4"
+  disabled={false}
+  href="#"
+  onClick={[Function]}
+>
+  <div
+    className="emotion-2 emotion-3"
+  >
+    <span
+      className="emotion-0 emotion-1"
+    >
+      Click me!
+    </span>
+  </div>
+</a>
+`;

--- a/src/shared-components/button/components/linkButton/index.js
+++ b/src/shared-components/button/components/linkButton/index.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Container from '../../shared-components/container';
+import { ButtonContents, ButtonText } from '../../style';
+import { linkButtonStyles } from './style';
+
+const propTypes = {
+  disabled: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  buttonType: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),
+  renderedTag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  onClick: PropTypes.func,
+};
+
+const defaultProps = {
+  disabled: false,
+  buttonType: 'primary',
+  renderedTag: 'a',
+  onClick() {},
+};
+
+const Link = ({
+  disabled,
+  children,
+  buttonType,
+  renderedTag,
+  onClick,
+  textColor,
+  ...rest
+}) => {
+  const ContainerTag = renderedTag;
+
+  return (
+    <ContainerTag
+      css={linkButtonStyles({ disabled, buttonType, textColor })}
+      disabled={disabled}
+      onClick={!disabled ? onClick : () => false}
+      {...rest}
+    >
+      <ButtonContents hasIcon={false}>
+        <ButtonText>{children}</ButtonText>
+      </ButtonContents>
+    </ContainerTag>
+  );
+};
+
+Link.propTypes = propTypes;
+Link.defaultProps = defaultProps;
+Link.Container = Container;
+
+export default Link;

--- a/src/shared-components/button/components/linkButton/index.js
+++ b/src/shared-components/button/components/linkButton/index.js
@@ -8,7 +8,7 @@ import { linkButtonStyles } from './style';
 const propTypes = {
   disabled: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  buttonType: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),
+  buttonType: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'quaternary']),
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   onClick: PropTypes.func,
 };

--- a/src/shared-components/button/components/linkButton/index.js
+++ b/src/shared-components/button/components/linkButton/index.js
@@ -9,14 +9,14 @@ const propTypes = {
   disabled: PropTypes.bool,
   children: PropTypes.node.isRequired,
   buttonType: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),
-  renderedTag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   onClick: PropTypes.func,
 };
 
 const defaultProps = {
   disabled: false,
   buttonType: 'primary',
-  renderedTag: 'a',
+  as: 'a',
   onClick() {},
 };
 
@@ -24,12 +24,12 @@ const Link = ({
   disabled,
   children,
   buttonType,
-  renderedTag,
+  as,
   onClick,
   textColor,
   ...rest
 }) => {
-  const ContainerTag = renderedTag;
+  const ContainerTag = as;
 
   return (
     <ContainerTag

--- a/src/shared-components/button/components/linkButton/style.js
+++ b/src/shared-components/button/components/linkButton/style.js
@@ -1,0 +1,13 @@
+import { css } from '@emotion/core';
+
+import { baseButtonStyles } from "../../style";
+import { COLORS } from '../../../../constants';
+
+/* eslint-disable-next-line import/prefer-default-export */
+export const linkButtonStyles = ({ disabled, buttonType, textColor }) => css`
+  ${baseButtonStyles({ disabled, buttonType, textColor })}
+
+  span {
+    ${disabled && `color: ${COLORS.textDisabled};`}
+  }
+`;

--- a/src/shared-components/button/components/linkButton/test.js
+++ b/src/shared-components/button/components/linkButton/test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import renderer from 'react-test-renderer';
+
+import LinkButton from './index';
+
+describe('<LinkButton/>', () => {
+  describe('UI snapshots', () => {
+    it('renders with props', () => {
+      const tree = renderer
+        .create(
+          <LinkButton onClick={() => {}} href="#">Click me!</LinkButton>
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('href handling', () => {
+    it('should link to a path', () => {
+      const wrapper = shallow(
+        <LinkButton href="/some/path">text</LinkButton>
+      );
+
+      expect(wrapper.prop('href')).toEqual("/some/path");
+    });
+  });
+
+  describe('onClick callback', () => {
+    it('should be invoked onClick', () => {
+      const spy = jest.fn();
+
+      const button = shallow(
+        <LinkButton onClick={spy}>text</LinkButton>
+      );
+
+      button.simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should not be invoked if disabled', () => {
+      const spy = jest.fn();
+
+      const button = shallow(
+        <LinkButton disabled href="#" onClick={spy}>text</LinkButton>
+      );
+
+      button.simulate('click');
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared-components/button/index.js
+++ b/src/shared-components/button/index.js
@@ -75,5 +75,6 @@ class Button extends React.Component {
   }
 }
 
+export LinkButton from './components/linkButton';
 export RoundButton from './components/roundButton';
 export default Button;

--- a/src/shared-components/button/style.js
+++ b/src/shared-components/button/style.js
@@ -98,7 +98,7 @@ function parseTheme(disabled, buttonType, loading) {
   }
 }
 
-const baseButtonStyles = ({ disabled, buttonType, loading, textColor }) => css`
+export const baseButtonStyles = ({ disabled, buttonType, loading, textColor }) => css`
   ${TYPOGRAPHY_STYLE.button};
   appearance: none;
   border-radius: 0;
@@ -148,17 +148,14 @@ export const ButtonContents = styled.div`
 
   ${({ loading, hasIcon }) => {
     if (loading && hasIcon) {
-      return css`
-        transform: translateX(-30px);
-      `;
-    } else if (loading && !hasIcon) {
-      return css`
-        transform: translateX(-15px);
-      `;
+      return css`transform: translateX(-30px);`;
     }
-    return css`
-      transform: translateX(0);
-    `;
+
+    if (loading && !hasIcon) {
+      return css`transform: translateX(-15px);`;
+    }
+
+    return css`transform: translateX(0);`;
   }};
 
   & > svg {
@@ -169,7 +166,6 @@ export const ButtonContents = styled.div`
   }
 `;
 
-/* eslint-disable indent */
 export const ButtonText = styled.span`
   line-height: 1.5;
   margin: 0;
@@ -183,4 +179,3 @@ export const ButtonText = styled.span`
     }
   }};
 `;
-/* eslint-enable indent */

--- a/src/shared-components/index.js
+++ b/src/shared-components/index.js
@@ -1,14 +1,14 @@
 export { default as Accordion } from './accordion';
 export { default as Alert } from './alert';
 export { default as Banner } from './banner';
-export { default as Button, RoundButton } from './button';
+export { default as Button, RoundButton, LinkButton  } from './button';
 export { default as Checkbox } from './checkbox';
 export { default as Chip } from './chip';
 export { default as Container } from './container';
+export { default as Dropdown } from './dropdown';
 export { default as ImmersiveModal } from './immersiveModal';
 export { default as LoadingSpinner } from './loadingSpinner';
 export { default as Modal } from './modal';
 export { default as OffClickWrapper } from './offClickWrapper';
-export { default as Dropdown } from './dropdown';
 export { default as RadioButton } from './radioButton';
 export { default as Typography, style as TYPOGRAPHY_STYLE } from './typography';

--- a/stories/button/index.js
+++ b/stories/button/index.js
@@ -170,6 +170,7 @@ stories.add(
         <LinkButton href="https://www.latlmes.com/arts/return-of-the-golden-age-of-comics-1">Primary</LinkButton>
         <LinkButton buttonType="secondary">Secondary</LinkButton>
         <LinkButton buttonType="tertiary">Tertiary</LinkButton>
+        <LinkButton buttonType="quaternary">Quaternary</LinkButton>
         <LinkButton disabled>Disabled</LinkButton>
       </Container>
 
@@ -179,7 +180,7 @@ stories.add(
 
       <Container title="with Knobs">
         <LinkButton
-          buttonType={select('buttonType', ['primary', 'secondary', 'tertiary'], 'primary')}
+          buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary'], 'primary')}
           disabled={boolean('disabled', false)}
           onClick={action('You clicked a button')}
           textColor={text('textColor', '')}

--- a/stories/button/index.js
+++ b/stories/button/index.js
@@ -174,7 +174,7 @@ stories.add(
       </Container>
 
       <Container title="Using React Router Link">
-        <LinkButton to="https://www.google.com/search?q=chem+trails" renderedTag={MockLink}>Router Link</LinkButton>
+        <LinkButton to="https://www.google.com/search?q=chem+trails" as={MockLink}>Router Link</LinkButton>
       </Container>
 
       <Container title="with Knobs">

--- a/stories/button/index.js
+++ b/stories/button/index.js
@@ -7,12 +7,12 @@ import { css } from '@emotion/core';
 
 import ButtonReadme from 'docs/button.md';
 import RoundButtonReadme from 'docs/roundButton.md';
+import LinkButtonReadme from 'docs/linkButton.md';
 import { CheckmarkIcon, ArrowLeftIcon, ArrowRightIcon } from 'src/svgs/icons';
-import { Button, RoundButton, Typography } from 'src/shared-components';
+import { Button, RoundButton, LinkButton, Typography } from 'src/shared-components';
 import { SPACING } from 'src/constants';
 
 const stories = storiesOf('Buttons', module);
-
 stories.addDecorator(withKnobs);
 
 stories.add(
@@ -145,6 +145,48 @@ stories.add(
           {text('children', 'Click me!')}
         </RoundButton>
       </RoundButton.Container>
+    </React.Fragment>
+  ))
+);
+
+// eslint-disable-next-line react/prop-types
+const Container = ({ title, children }) => (
+  <LinkButton.Container css={css`display: block; padding-bottom: 50px;`}>
+    <Typography.Heading css={css`text-align: left;`}>{title}</Typography.Heading>
+    {children}
+  </LinkButton.Container>
+);
+
+// Mock React-Router Link for story.
+const MockLink = ({ to, children, ...rest }) => (
+  <a href={to} {...rest}>{children}</a>
+);
+
+stories.add(
+  'LinkButton',
+  withDocs(LinkButtonReadme, () => (
+    <React.Fragment>
+      <Container title="LinkButton">
+        <LinkButton href="https://www.latlmes.com/arts/return-of-the-golden-age-of-comics-1">Primary</LinkButton>
+        <LinkButton buttonType="secondary">Secondary</LinkButton>
+        <LinkButton buttonType="tertiary">Tertiary</LinkButton>
+        <LinkButton disabled>Disabled</LinkButton>
+      </Container>
+
+      <Container title="Using React Router Link">
+        <LinkButton to="https://www.google.com/search?q=chem+trails" renderedTag={MockLink}>Router Link</LinkButton>
+      </Container>
+
+      <Container title="with Knobs">
+        <LinkButton
+          buttonType={select('buttonType', ['primary', 'secondary', 'tertiary'], 'primary')}
+          disabled={boolean('disabled', false)}
+          onClick={action('You clicked a button')}
+          textColor={text('textColor', '')}
+        >
+          {text('children', 'Click it!')}
+        </LinkButton>
+      </Container>
     </React.Fragment>
   ))
 );


### PR DESCRIPTION
## Adds the `LinkButton` component to the Radiance package.

![linkButton](https://user-images.githubusercontent.com/38407520/54324035-1da30500-45b9-11e9-8fdd-4ec32820dff5.gif)

### React Router support

You can now pass in React Router's `Link`/`NavLink` as a prop.

```jsx
import { Link } from 'react-router';

<LinkButton to="/somepath" renderedTag={Link}>
  Click me!
</LinkButton>
```

