### PR TITLE
Refactor LoadingSpinner: html semantic

### DIFF
--- a/src/shared-components/loadingSpinner/__snapshots__/test.js.snap
+++ b/src/shared-components/loadingSpinner/__snapshots__/test.js.snap
@@ -93,7 +93,7 @@ exports[`<LoadingSpinner /> UI snapshots renders the correct css 1`] = `
   animation-delay: -0.5s;
 }
 
-<section
+<div
   className="emotion-8 emotion-9"
   id="loading-spinner"
 >
@@ -116,5 +116,5 @@ exports[`<LoadingSpinner /> UI snapshots renders the correct css 1`] = `
       size="14px"
     />
   </div>
-</section>
+</div>
 `;

--- a/src/shared-components/loadingSpinner/index.js
+++ b/src/shared-components/loadingSpinner/index.js
@@ -2,12 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { COLORS } from '../../constants';
-import { Container, Overlay, Dot } from './style';
+import { LoadingSpinnerContainer, Overlay, Dot } from './style';
 
-const LoadingSpinner = ({
-  bgColor, color, translateX, duration, size, 
-}) => (
-  <Container bgColor={bgColor} id="loading-spinner">
+const LoadingSpinner = ({ bgColor, color, translateX, duration, size }) => (
+  <LoadingSpinnerContainer bgColor={bgColor} id="loading-spinner">
     <Overlay>
       <Dot
         color={color}
@@ -28,7 +26,7 @@ const LoadingSpinner = ({
         size={size}
       />
     </Overlay>
-  </Container>
+  </LoadingSpinnerContainer>
 );
 
 LoadingSpinner.propTypes = {

--- a/src/shared-components/loadingSpinner/style.js
+++ b/src/shared-components/loadingSpinner/style.js
@@ -7,7 +7,7 @@ const appPreloader = translateX => keyframes`
   100% { opacity: 0; transform: translate3d(-${translateX}, 0, 0) }
 `;
 
-export const Container = styled.section`
+export const LoadingSpinnerContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/stories/carousel/index.js
+++ b/stories/carousel/index.js
@@ -19,7 +19,7 @@ const MainContainer = styled.div`
   text-align: left;
 `;
 
-const FlexContainer = styled.section`
+const FlexContainer = styled.div`
   display: flex;
   flex-flow: row wrap;
   justify-content: flex-start;


### PR DESCRIPTION
- This can be considered as refactor to a  more html semantic version
- It was discovered in a bug for a gatsby build where the Spinner as a `<section>` was messing up the rendered layout when it has siblings `section` tags.
- https://trello.com/c/O1XyO0aW/478-bug-restricted-page-is-breaking-how-pages-render-after-auth-on-netlify