### PR TITLE
Tabs Component initial

### DIFF
--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -4,54 +4,23 @@
 ```jsx
 import { Tabs } from 'radiance-ui';
 
-const Content = styled.div`
-  ${TYPOGRAPHY_STYLE.display};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  background-color: ${props => props.bgColor};
-  color: ${COLORS.primary};
-  height: calc(100vh / 2);
-`;
-
-class TabsExample extends React.Component {
-  state = {
-    activeTabId: 1,
-  };
-
-  tabItems = [
-    { id: 1, text: 'Tab 1', bgColor: COLORS.postcardGreen },
-    { id: 2, text: 'Tab 2', bgColor: COLORS.postcardPeach },
-    { id: 3, text: 'Tab 3', bgColor: COLORS.postcardYellow },
+const TabsExample = () => {
+  const tabItems = [
+    { id: 1, text: 'Tab 1' },
+    { id: 2, text: 'Tab 2' },
+    { id: 3, text: 'Tab 3' },
   ];
 
-  onClickTab = tab => {
-    this.setState({ activeTabId: tab.id });
+  const onClickTab = tab => {
+    console.log(tab);
   };
 
-  renderContent = () => {
-    const { activeTabId } = this.state;
-    const tab = this.tabItems.find(tabItem => tabItem.id === activeTabId);
-
-    return <Content bgColor={tab.bgColor}>{tab.text}</Content>;
-  };
-
-  render() {
-    const { activeTabId } = this.state;
-
-    return (
-      <section>
-        <Tabs
-          activeTabId={activeTabId}
-          tabItems={this.tabItems}
-          onClick={this.onClickTab}
-        />
-        {this.renderContent()}
-      </section>
-    );
-  }
-}
+  return (
+    <section>
+      <Tabs initialActiveTabId={1} tabItems={tabItems} onClick={onClickTab} />
+    </section>
+  );
+};
 ```
 
 <!-- STORY -->
@@ -59,9 +28,9 @@ class TabsExample extends React.Component {
 ### Proptypes
 | prop                | propType          | required  | default   | description                                                                                                                  
 |---------------------|-------------------|-----------|-----------|-------------------------------|
-| tabItems            | array of objects  | yes       | -         | see tabItems properties below |
-| onClick             | number            | no        | -         | function to call on tab click |
 | initialActiveTabId  | number            | no        | 1         | initial tab id to display     |
+| onClick             | number            | no        | -         | function to call on tab click |
+| tabItems            | array of objects  | yes       | -         | see tabItems properties below |
 
 
 #### `tabItems` Proptypes

--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -1,0 +1,71 @@
+# Tabs
+### Usage
+
+```jsx
+import { Tabs } from 'radiance-ui';
+
+const Content = styled.div`
+  ${TYPOGRAPHY_STYLE.display};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: ${props => props.bgColor};
+  color: ${COLORS.primary};
+  height: calc(100vh / 2);
+`;
+
+class TabsExample extends React.Component {
+  state = {
+    activeTabId: 1,
+  };
+
+  tabItems = [
+    { id: 1, text: 'Tab 1', bgColor: COLORS.postcardGreen },
+    { id: 2, text: 'Tab 2', bgColor: COLORS.postcardPeach },
+    { id: 3, text: 'Tab 3', bgColor: COLORS.postcardYellow },
+  ];
+
+  onClickTab = tab => {
+    this.setState({ activeTabId: tab.id });
+  };
+
+  renderContent = () => {
+    const { activeTabId } = this.state;
+    const tab = this.tabItems.find(tabItem => tabItem.id === activeTabId);
+
+    return <Content bgColor={tab.bgColor}>{tab.text}</Content>;
+  };
+
+  render() {
+    const { activeTabId } = this.state;
+
+    return (
+      <section>
+        <Tabs
+          activeTabId={activeTabId}
+          tabItems={this.tabItems}
+          onClick={this.onClickTab}
+        />
+        {this.renderContent()}
+      </section>
+    );
+  }
+}
+```
+
+<!-- STORY -->
+
+### Proptypes
+| prop                | propType          | required  | default   | description                                                                                                                  
+|---------------------|-------------------|-----------|-----------|-------------------------------|
+| tabItems            | array of objects  | yes       | -         | see tabItems properties below |
+| onClick             | number            | no        | -         | function to call on tab click |
+| initialActiveTabId  | number            | no        | 1         | initial tab id to display     |
+
+
+#### `tabItems` Proptypes
+| prop      | propType | description                    |
+| --------  | -------- | ------------------------------ |
+| id        | number   | the tab indentifier                |
+| text      | string   | the title of the tab           |

--- a/src/shared-components/index.js
+++ b/src/shared-components/index.js
@@ -17,5 +17,6 @@ export { default as LoadingSpinner } from './loadingSpinner';
 export { default as Modal } from './modal';
 export { default as OffClickWrapper } from './offClickWrapper';
 export { default as RadioButton } from './radioButton';
+export { default as Tabs } from './tabs';
 export { default as Tooltip } from './tooltip';
 export { default as Typography, style as TYPOGRAPHY_STYLE } from './typography';

--- a/src/shared-components/tabs/index.js
+++ b/src/shared-components/tabs/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { TabSection, TabContainer, TabItem } from './style';
+import { TabsContainer, TabItem } from './style';
 
 class Tabs extends React.Component {
   static propTypes = {
@@ -36,19 +36,17 @@ class Tabs extends React.Component {
     const { activeTabId } = this.state;
 
     return (
-      <TabSection>
-        <TabContainer>
-          {tabItems.map(tab => (
-            <TabItem
-              active={tab.id === activeTabId}
-              key={tab.id}
-              onClick={() => this.onTabClick(tab)}
-            >
-              {tab.text}
-            </TabItem>
-          ))}
-        </TabContainer>
-      </TabSection>
+      <TabsContainer>
+        {tabItems.map(tab => (
+          <TabItem
+            active={tab.id === activeTabId}
+            key={tab.id}
+            onClick={() => this.onTabClick(tab)}
+          >
+            {tab.text}
+          </TabItem>
+        ))}
+      </TabsContainer>
     );
   }
 }

--- a/src/shared-components/tabs/index.js
+++ b/src/shared-components/tabs/index.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { TabSection, TabContainer, TabItem } from './style';
+
+class Tabs extends React.Component {
+  static propTypes = {
+    tabItems: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        text: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+    onClick: PropTypes.func,
+    initialActiveTabId: PropTypes.number,
+  };
+
+  static defaultProps = {
+    onClick() {},
+    initialActiveTabId: 1,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { activeTabId: props.initialActiveTabId };
+  }
+
+  onTabClick = tab => {
+    const { onClick } = this.props;
+    this.setState({ activeTabId: tab.id });
+    onClick(tab);
+  };
+
+  render() {
+    const { tabItems } = this.props;
+    const { activeTabId } = this.state;
+
+    return (
+      <TabSection>
+        <TabContainer>
+          {tabItems.map(tab => (
+            <TabItem
+              active={tab.id === activeTabId}
+              key={tab.id}
+              onClick={() => this.onTabClick(tab)}
+            >
+              {tab.text}
+            </TabItem>
+          ))}
+        </TabContainer>
+      </TabSection>
+    );
+  }
+}
+
+export default Tabs;

--- a/src/shared-components/tabs/index.js
+++ b/src/shared-components/tabs/index.js
@@ -5,19 +5,19 @@ import { TabsContainer, TabItem } from './style';
 
 class Tabs extends React.Component {
   static propTypes = {
+    initialActiveTabId: PropTypes.number,
+    onClick: PropTypes.func,
     tabItems: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.number.isRequired,
         text: PropTypes.string.isRequired,
       })
     ).isRequired,
-    onClick: PropTypes.func,
-    initialActiveTabId: PropTypes.number,
   };
 
   static defaultProps = {
-    onClick() {},
     initialActiveTabId: 1,
+    onClick() {},
   };
 
   constructor(props) {

--- a/src/shared-components/tabs/style.js
+++ b/src/shared-components/tabs/style.js
@@ -1,21 +1,21 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { COLORS, SPACING, ANIMATION } from '../../constants';
+import { COLORS, SPACING, ANIMATION, MEDIA_QUERIES } from '../../constants';
 
-export const TabSection = styled.section`
+export const TabsContainer = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
-`;
-
-export const TabContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  margin: ${SPACING.xlarge} 0 0;
+  justify-content: flex-start;
+  margin: ${SPACING.large} 0 0 0;
   position: relative;
+  width: 100%;
+
+  ${MEDIA_QUERIES.mdUp} {
+    margin: ${SPACING.xlarge} 0 0 0;
+    align-items: center;
+    justify-content: center;
+  }
 `;
 
 export const TabItem = styled.div`

--- a/src/shared-components/tabs/style.js
+++ b/src/shared-components/tabs/style.js
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+
+import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { COLORS, SPACING, ANIMATION } from '../../constants';
+
+export const TabSection = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const TabContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin: ${SPACING.xlarge} 0 0;
+  position: relative;
+`;
+
+export const TabItem = styled.div`
+  ${TYPOGRAPHY_STYLE.button};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin: 0;
+  padding: ${SPACING.small} ${SPACING.base};
+  transition: ${ANIMATION.defaultTiming};
+
+  color: ${({ active }) => (active ? COLORS.primary : COLORS.primaryTint3)};
+
+  &:hover {
+    color: ${COLORS.primary};
+    transition: ${ANIMATION.defaultTiming};
+  }
+`;

--- a/src/shared-components/tabs/test.js
+++ b/src/shared-components/tabs/test.js
@@ -12,16 +12,16 @@ describe('<Tabs />', () => {
         <Tabs
           activeTabId={1}
           tabItems={[
-            { id: 1, text: 'Rain Drop' },
-            { id: 2, text: 'Drop Top' },
-            { id: 3, text: 'Tab number 3' },
+            { id: 1, text: 'Tab 1' },
+            { id: 2, text: 'Tab 2' },
+            { id: 3, text: 'Tab 3' },
           ]}
         />
       );
 
-      expect(wrapper.html().indexOf('Rain Drop') > -1).toBe(true);
-      expect(wrapper.html().indexOf('Drop Top') > -1).toBe(true);
-      expect(wrapper.html().indexOf('Tab number 3') > -1).toBe(true);
+      expect(wrapper.html().indexOf('Tab 1') > -1).toBe(true);
+      expect(wrapper.html().indexOf('Tab 2') > -1).toBe(true);
+      expect(wrapper.html().indexOf('Tab 3') > -1).toBe(true);
     });
   });
 
@@ -32,9 +32,9 @@ describe('<Tabs />', () => {
         <Tabs
           activeTabId={1}
           tabItems={[
-            { id: 1, text: 'Rain Drop' },
-            { id: 2, text: 'Drop Top' },
-            { id: 3, text: 'If Seiji notices I will stop stop' },
+            { id: 1, text: 'Tab 1' },
+            { id: 2, text: 'Tab 2' },
+            { id: 3, text: 'Tab 3' },
           ]}
           onClick={spy}
         />
@@ -45,7 +45,7 @@ describe('<Tabs />', () => {
         .first()
         .simulate('click');
 
-      expect(spy).toHaveBeenCalledWith({ id: 1, text: 'Rain Drop' });
+      expect(spy).toHaveBeenCalledWith({ id: 1, text: 'Tab 1' });
     });
   });
 });

--- a/src/shared-components/tabs/test.js
+++ b/src/shared-components/tabs/test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { TabItem } from './style';
+
+import Tabs from './index';
+
+describe('<Tabs />', () => {
+  describe('default props', () => {
+    test('renders the correct props', () => {
+      const wrapper = shallow(
+        <Tabs
+          activeTabId={1}
+          tabItems={[
+            { id: 1, text: 'Rain Drop' },
+            { id: 2, text: 'Drop Top' },
+            { id: 3, text: 'Tab number 3' },
+          ]}
+        />
+      );
+
+      expect(wrapper.html().indexOf('Rain Drop') > -1).toBe(true);
+      expect(wrapper.html().indexOf('Drop Top') > -1).toBe(true);
+      expect(wrapper.html().indexOf('Tab number 3') > -1).toBe(true);
+    });
+  });
+
+  describe('on click function', () => {
+    test('returns correct params', () => {
+      const spy = jest.fn();
+      const wrapper = mount(
+        <Tabs
+          activeTabId={1}
+          tabItems={[
+            { id: 1, text: 'Rain Drop' },
+            { id: 2, text: 'Drop Top' },
+            { id: 3, text: 'If Seiji notices I will stop stop' },
+          ]}
+          onClick={spy}
+        />
+      );
+
+      wrapper
+        .find(TabItem)
+        .first()
+        .simulate('click');
+
+      expect(spy).toHaveBeenCalledWith({ id: 1, text: 'Rain Drop' });
+    });
+  });
+});

--- a/stories/tabs/TabsExample.js
+++ b/stories/tabs/TabsExample.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import { Tabs, TYPOGRAPHY_STYLE } from 'src/shared-components';
+import { COLORS } from 'src/constants';
+
+const Content = styled.div`
+  ${TYPOGRAPHY_STYLE.display};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: ${props => props.bgColor};
+  color: ${COLORS.primary};
+  height: calc(100vh / 2);
+`;
+
+class TabsExample extends React.Component {
+  state = {
+    activeTabId: 1,
+  };
+
+  tabItems = [
+    { id: 1, text: 'Tab 1', bgColor: COLORS.postcardGreen },
+    { id: 2, text: 'Tab 2', bgColor: COLORS.postcardPeach },
+    { id: 3, text: 'Tab 3', bgColor: COLORS.postcardYellow },
+  ];
+
+  onClickTab = tab => {
+    this.setState({ activeTabId: tab.id });
+  };
+
+  renderContent = () => {
+    const { activeTabId } = this.state;
+    const tab = this.tabItems.find(tabItem => tabItem.id === activeTabId);
+
+    return <Content bgColor={tab.bgColor}>{tab.text}</Content>;
+  };
+
+  render() {
+    const { activeTabId } = this.state;
+
+    return (
+      <section>
+        <Tabs
+          activeTabId={activeTabId}
+          tabItems={this.tabItems}
+          onClick={this.onClickTab}
+        />
+        {this.renderContent()}
+      </section>
+    );
+  }
+}
+
+export default TabsExample;

--- a/stories/tabs/TabsExample.js
+++ b/stories/tabs/TabsExample.js
@@ -1,56 +1,23 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
-import { Tabs, TYPOGRAPHY_STYLE } from 'src/shared-components';
-import { COLORS } from 'src/constants';
+import { Tabs } from 'src/shared-components';
 
-const Content = styled.div`
-  ${TYPOGRAPHY_STYLE.display};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  background-color: ${props => props.bgColor};
-  color: ${COLORS.primary};
-  height: calc(100vh / 2);
-`;
-
-class TabsExample extends React.Component {
-  state = {
-    activeTabId: 1,
-  };
-
-  tabItems = [
-    { id: 1, text: 'Tab 1', bgColor: COLORS.postcardGreen },
-    { id: 2, text: 'Tab 2', bgColor: COLORS.postcardPeach },
-    { id: 3, text: 'Tab 3', bgColor: COLORS.postcardYellow },
+const TabsExample = () => {
+  const tabItems = [
+    { id: 1, text: 'Tab 1' },
+    { id: 2, text: 'Tab 2' },
+    { id: 3, text: 'Tab 3' },
   ];
 
-  onClickTab = tab => {
-    this.setState({ activeTabId: tab.id });
+  const onClickTab = tab => {
+    console.log(tab);
   };
 
-  renderContent = () => {
-    const { activeTabId } = this.state;
-    const tab = this.tabItems.find(tabItem => tabItem.id === activeTabId);
-
-    return <Content bgColor={tab.bgColor}>{tab.text}</Content>;
-  };
-
-  render() {
-    const { activeTabId } = this.state;
-
-    return (
-      <section>
-        <Tabs
-          activeTabId={activeTabId}
-          tabItems={this.tabItems}
-          onClick={this.onClickTab}
-        />
-        {this.renderContent()}
-      </section>
-    );
-  }
-}
+  return (
+    <section>
+      <Tabs initialActiveTabId={1} tabItems={tabItems} onClick={onClickTab} />
+    </section>
+  );
+};
 
 export default TabsExample;

--- a/stories/tabs/index.js
+++ b/stories/tabs/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { storiesOf } from '@storybook/react';
+import { withDocs } from 'storybook-readme';
+
+import TabsReadme from 'docs/tabs.md';
+import { Typography } from 'src/shared-components';
+
+import TabsExample from './TabsExample';
+
+const MainContainer = styled.div`
+  text-align: left;
+`;
+
+const stories = storiesOf('Tabs', module);
+stories.add(
+  'Usage',
+  withDocs(TabsReadme, () => (
+    <MainContainer>
+      <Typography.Heading>Example:</Typography.Heading>
+      <TabsExample />
+    </MainContainer>
+  ))
+);


### PR DESCRIPTION
- Similar to Form component this is the initial version compatible with PocketDerm. However:
- I dont like how it handle the Tabs as object {id,title}, worse it couples the initialTab to Id=1 forcing us to provide at least one Tab object with Id=1
- I propose drop the tab objects and just work with arrays of string titles and the active Id would be the index now. As usual this would require more refactor in PocketDerm as well.