### PR TITLE
Transition components

### DIFF
--- a/docs/transitions/fadeInContainer.md
+++ b/docs/transitions/fadeInContainer.md
@@ -7,9 +7,8 @@ import { FadeInContainer, Container } from 'radiance-ui';
 <FadeInContainer slide>
   <Container type="message">
     <Container.Section>
-      FadeInContainer has an animation on the inital render. <br />
-      You can use this in subcomponents to have a transition between app
-      states.
+      FadeInContainer has an opacity fade in animation on the inital render.<br />
+      You can add the slide property for an extra slide in animation.
     </Container.Section>
   </Container>
 </FadeInContainer>

--- a/docs/transitions/fadeInContainer.md
+++ b/docs/transitions/fadeInContainer.md
@@ -1,0 +1,24 @@
+# FadeInContainer
+### Usage
+
+```jsx
+import { FadeInContainer, Container } from 'radiance-ui';
+
+<FadeInContainer slide>
+  <Container type="message">
+    <Container.Section>
+      FadeInContainer has an animation on the inital render. <br />
+      You can use this in subcomponents to have a transition between app
+      states.
+    </Container.Section>
+  </Container>
+</FadeInContainer>
+```
+
+<!-- STORY -->
+
+### Proptypes
+| prop      | propType          | required | default    | description                                                                                                                  
+|-----------|-------------------|----------|------------|---------------------------------|
+| slide     | bool              | no       | false      | adds a slide in animation       |
+| speed     | string            | no       | 350ms      | the animation transition speed  |

--- a/docs/transitions/opacityInAnimationStyle.md
+++ b/docs/transitions/opacityInAnimationStyle.md
@@ -1,0 +1,17 @@
+# opacityInAnimationStyle
+### Usage
+
+```jsx
+import styled from '@emotion/styled'
+import { opacityInAnimationStyle } from 'radiance-ui';
+
+export const CustomFadeInContainer = styled.div`
+  ${opacityInAnimationStyle};
+`;
+
+<CustomFadeInContainer>
+  opacityInAnimationStyle is a shorthand for a fade in animation to be used in the current style code.
+</CustomFadeInContainer>
+```
+
+<!-- STORY -->

--- a/docs/transitions/opacityInAnimationStyle.md
+++ b/docs/transitions/opacityInAnimationStyle.md
@@ -10,7 +10,7 @@ export const CustomFadeInContainer = styled.div`
 `;
 
 <CustomFadeInContainer>
-  opacityInAnimationStyle is a shorthand for a fade in animation to be used in the current style code.
+  opacityInAnimationStyle is a snippet for a fade in animation to be used in the current emotion style code.
 </CustomFadeInContainer>
 ```
 

--- a/src/shared-components/index.js
+++ b/src/shared-components/index.js
@@ -21,3 +21,4 @@ export { default as RadioButton } from './radioButton';
 export { default as Tabs } from './tabs';
 export { default as Tooltip } from './tooltip';
 export { default as Typography, style as TYPOGRAPHY_STYLE } from './typography';
+export { FadeInContainer, opacityInAnimationStyle } from './transitions';

--- a/src/shared-components/transitions/__snapshots__/test.js.snap
+++ b/src/shared-components/transitions/__snapshots__/test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FadeInContainer /> UI snapshot renders component and children 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: translateY(-10%);
+    -ms-transform: translateY(-10%);
+    transform: translateY(-10%);
+    opacity: 0;
+  }
+
+  25% {
+    opacity: 0;
+  }
+
+  100% {
+    -webkit-transform: translateY(0%);
+    -ms-transform: translateY(0%);
+    transform: translateY(0%);
+    opacity: 1;
+  }
+}
+
+.emotion-0 {
+  -webkit-animation: animation-0 500ms ease-in-out;
+  animation: animation-0 500ms ease-in-out;
+}
+
+<div
+  className="emotion-0 emotion-1"
+  speed="500ms"
+>
+  FadeInContainer Content Here
+</div>
+`;

--- a/src/shared-components/transitions/index.js
+++ b/src/shared-components/transitions/index.js
@@ -1,0 +1,1 @@
+export { FadeInContainer, opacityInAnimationStyle } from './style';

--- a/src/shared-components/transitions/style.js
+++ b/src/shared-components/transitions/style.js
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { css, keyframes } from '@emotion/core';
+
+import { ANIMATION } from '../../constants';
+
+const slideInAnimation = keyframes`
+  0% {
+    transform: translateY(-10%);
+    opacity: 0;
+  }
+
+  25% {
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+`;
+
+const opacityInAnimation = keyframes`
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+`;
+
+const getAnimationStyle = (slide = false, speed = '350ms') => {
+  if (slide) {
+    return css`
+      animation: ${slideInAnimation} ${speed} ease-in-out;
+    `;
+  }
+  return css`
+    animation: ${opacityInAnimation} ${speed} ease-in-out;
+  `;
+};
+
+export const FadeInContainer = styled.div`
+  ${({ slide, speed }) => getAnimationStyle(slide, speed)};
+`;
+
+export const opacityInAnimationStyle = css`
+  animation: ${opacityInAnimation} ${ANIMATION.defaultTiming} ease-in-out;
+`;

--- a/src/shared-components/transitions/style.js
+++ b/src/shared-components/transitions/style.js
@@ -35,6 +35,7 @@ const getAnimationStyle = (slide = false, speed = '350ms') => {
       animation: ${slideInAnimation} ${speed} ease-in-out;
     `;
   }
+
   return css`
     animation: ${opacityInAnimation} ${speed} ease-in-out;
   `;

--- a/src/shared-components/transitions/test.js
+++ b/src/shared-components/transitions/test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { FadeInContainer } from './index';
+
+describe('<FadeInContainer />', () => {
+  describe('UI snapshot', () => {
+    it('renders component and children', () => {
+      const component = renderer.create(
+        <FadeInContainer slide speed="500ms">
+          FadeInContainer Content Here
+        </FadeInContainer>
+      );
+
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/stories/transitions/index.js
+++ b/stories/transitions/index.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withDocs } from 'storybook-readme';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import styled from '@emotion/styled';
+
+import FadeInContainerReadme from 'docs/transitions/fadeInContainer.md';
+import OpacityInReadme from 'docs/transitions/opacityInAnimationStyle.md';
+import {
+  FadeInContainer,
+  opacityInAnimationStyle,
+  Container,
+} from 'src/shared-components';
+
+const MainContainer = styled.div`
+  text-align: left;
+  min-height: 150px;
+`;
+
+const InnerContainer = styled.div`
+  display: ${({ render }) => (render ? 'block' : 'none')};
+`;
+
+const CustomFadeInContainer = styled.div`
+  ${opacityInAnimationStyle};
+`;
+
+const stories = storiesOf('Transitions', module);
+stories.addDecorator(withKnobs);
+
+stories.add(
+  'FadeInContainer',
+  withDocs(FadeInContainerReadme, () => (
+    <MainContainer>
+      <InnerContainer render={boolean('Toggle to reset the animation', true)}>
+        <FadeInContainer
+          slide={boolean('slide', true)}
+          speed={text('speed', '350ms')}
+        >
+          <Container type="message">
+            <Container.Section>
+              FadeInContainer has an opacity fade in animation on the inital
+              render. <br />
+              You can add the slide property for an extra slide in animation.
+            </Container.Section>
+          </Container>
+        </FadeInContainer>
+      </InnerContainer>
+    </MainContainer>
+  ))
+);
+
+stories.add(
+  'opacityInAnimationStyle',
+  withDocs(OpacityInReadme, () => (
+    <MainContainer>
+      <InnerContainer render={boolean('Toggle to reset the animation', true)}>
+        <CustomFadeInContainer>
+          opacityInAnimationStyle is a shorthand for a fade in animation to be
+          used in the current style code.
+        </CustomFadeInContainer>
+      </InnerContainer>
+    </MainContainer>
+  ))
+);

--- a/stories/transitions/index.js
+++ b/stories/transitions/index.js
@@ -56,8 +56,8 @@ stories.add(
     <MainContainer>
       <InnerContainer render={boolean('Toggle to reset the animation', true)}>
         <CustomFadeInContainer>
-          opacityInAnimationStyle is a shorthand for a fade in animation to be
-          used in the current style code.
+          opacityInAnimationStyle is a snippet for a fade in animation to be
+          used in the current emotion style code.
         </CustomFadeInContainer>
       </InnerContainer>
     </MainContainer>


### PR DESCRIPTION
- I combined both component from PocketDerm(FadeInContainer, OpacityInContainer) into only 1 since they were almost the same, except for the little slide animation added which I included as prop flag.

- I am not sure about `opacityInEffect` I included here to ease the refactor in PocketDerm, but I am open to suggestions since this is not a component, just a little style code shortcut. Maybe move somewhere in PocketDerm instead?
