### PR TITLE
Modal global fix

### DIFF
--- a/src/shared-components/modal/index.js
+++ b/src/shared-components/modal/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
+import { Global } from '@emotion/core';
 
 import CloseIcon from '../../svgs/icons/close-icon.svg';
 import keyPressMatch from '../../utils/keyPressMatch';
 import KEYCODES from '../../constants/keycodes';
 import {
-  ModalContainer,
   ModalOverlay,
   ModalBox,
   ModalCloseIcon,
@@ -90,12 +90,18 @@ class Modal extends React.Component {
 
   render() {
     const { isVisible } = this.state;
-    const {
-      isOpen, children, className, canBeClosed, 
-    } = this.props;
+    const { isOpen, children, className, canBeClosed } = this.props;
 
     return (
-      <ModalContainer>
+      <React.Fragment>
+        <Global
+          styles={{
+            '.ReactModalPortal': {
+              position: 'relative',
+              zIndex: 99999999,
+            },
+          }}
+        />
         <ReactModal
           className={`prevent-default ${className}`}
           contentLabel="Modal"
@@ -120,7 +126,7 @@ class Modal extends React.Component {
             </ModalBox>
           </ModalOverlay>
         </ReactModal>
-      </ModalContainer>
+      </React.Fragment>
     );
   }
 }

--- a/src/shared-components/modal/style.js
+++ b/src/shared-components/modal/style.js
@@ -3,13 +3,6 @@ import styled from '@emotion/styled';
 import Typography from '../typography';
 import { COLORS, MEDIA_QUERIES, SPACING } from '../../constants';
 
-export const ModalContainer = styled.div`
-  .ReactModalPortal {
-    position: relative;
-    z-index: 99999999;
-  }
-`;
-
 export const ModalOverlay = styled.div`
   -webkit-overflow-scrolling: touch;
   background-color: ${COLORS.overlay};
@@ -29,9 +22,8 @@ export const ModalOverlay = styled.div`
   }
 `;
 
-const determineScale = ({ isVisible }) => (
-  isVisible ? 'scale(1, 1)' : 'scale(0.95, 0.95)'
-);
+const determineScale = ({ isVisible }) =>
+  isVisible ? 'scale(1, 1)' : 'scale(0.95, 0.95)';
 
 export const ModalBox = styled.div`
   background-color: ${COLORS.white};
@@ -70,7 +62,7 @@ export const ContentContainer = styled.div`
 
   ${MEDIA_QUERIES.mdUp} {
     padding: ${({ tight }) =>
-    tight ? SPACING.large : `${SPACING.xlarge} 5rem`};
+      tight ? SPACING.large : `${SPACING.xlarge} 5rem`};
   }
 `;
 


### PR DESCRIPTION
- I review the code in action (I am refactoring to Radiance modal in PocketDerm)and We need to revert back to its original for regarding Global style to prevent this issue
![image](https://user-images.githubusercontent.com/11194969/56831741-508b1a80-6840-11e9-9e9b-776623c9f8bc.png)

- The way The Radiance Modal is now does not work and do nothing: the style applied to ModalContainer does not reach the .ReactModalPortal element because they are disconnected in runtime (modal is created on the fly below in the dom tree)

- According to Emotion docs, the global style injection is harmless and unmounts when the component does so. I tested and the global style does not get injected multiple times when opening the modal more than once so there is no memory leaks: https://emotion.sh/docs/globals


