### PR TITLE
Add "action" buttonType style to RoundButton

### DIFF
--- a/docs/button/roundButton.md
+++ b/docs/button/roundButton.md
@@ -3,46 +3,34 @@
 
 ```jsx
 import { RoundButton } from 'radiance-ui';
-import { CheckmarkIcon } from 'radiance-ui/lib/icons';
+import { CheckmarkIcon, ArrowRightIcon, ArrowLeftIcon, CloseIcon } from 'radiance-ui/lib/icons';
 
-<React.Fragment>
-  <RoundButton.Container multi>
-    <RoundButton icon={<CheckmarkIcon />}>Primary</RoundButton>
-    <RoundButton buttonType="secondary" icon={<ArrowRightIcon />}>
-      Secondary
-    </RoundButton>
-  </RoundButton.Container>
-  <RoundButton.Container multi>
-    <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />}>
-      Tertiary
-    </RoundButton>
-    <RoundButton buttonType="quaternary" icon={<ArrowRightIcon />}>
-      Quaternary
-    </RoundButton>
-  </RoundButton.Container>
-  <RoundButton.Container multi>
-    <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} disabled>
-      Disabled
-    </RoundButton>
-  </RoundButton.Container>
+// Default
+<RoundButton icon={<CheckmarkIcon />}>Primary</RoundButton>
+<RoundButton buttonType="secondary" icon={<ArrowRightIcon />}>Secondary</RoundButton>
+<RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />}>Tertiary</RoundButton>
+<RoundButton buttonType="quaternary" icon={<ArrowRightIcon />}>Quaternary</RoundButton>
+<RoundButton buttonType="action" icon={<CloseIcon />}>Action</RoundButton>
 
-  <RoundButton.Container multi>
-    <RoundButton icon={<ArrowLeftIcon />} loading>
-      Primary Loading
-    </RoundButton>
-    <RoundButton buttonType="secondary" icon={<ArrowRightIcon />} loading>
-      Secondary Loading
-    </RoundButton>
-  </RoundButton.Container>
-  <RoundButton.Container multi>
-    <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} loading>
-      Tertiary Loading
-    </RoundButton>
-    <RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} loading>
-      Quaternary Loading
-    </RoundButton>
-  </RoundButton.Container>
-</React.Fragment>
+// Disabled
+<RoundButton icon={<ArrowLeftIcon />} disabled>Primary</RoundButton>
+<RoundButton buttonType="secondary" icon={<ArrowRightIcon />} disabled>Secondary</RoundButton>
+<RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} disabled>Tertiary</RoundButton>
+<RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} disabled>Quaternary</RoundButton>
+<RoundButton buttonType="action" icon={<CloseIcon />} disabled>Action</RoundButton>
+
+// Loading
+<RoundButton icon={<ArrowLeftIcon />} loading>Primary</RoundButton>
+<RoundButton buttonType="secondary" icon={<ArrowRightIcon />} loading>Secondary</RoundButton>
+<RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} loading>Tertiary</RoundButton>
+<RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} loading>Quaternary</RoundButton>
+<RoundButton buttonType="action" icon={<CloseIcon />} loading>Action</RoundButton>
+
+// Within RoundButton.Container (with multi prop)
+<RoundButton.Container multi>
+  <RoundButton icon={<ArrowLeftIcon />} />
+  <RoundButton icon={<ArrowRightIcon />} />
+</RoundButton.Container>
 ```
 
 <!-- STORY -->
@@ -50,7 +38,7 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
 ### Proptypes
 | prop     | propType           | required | default | description                                                                                                                  |
 |----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`. |
+| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`, `action`. |
 | children | node | yes | - | node to be rendered inside the button.  Recommended to be the button text |
 | disabled | bool               | no       | false   | when disabled, click listener will not be called and the UI will look disabled |
 | icon | node | yes | null | icon to render in the button. Recommended to use one of Radiance's icons |

--- a/src/shared-components/button/components/roundButton/index.js
+++ b/src/shared-components/button/components/roundButton/index.js
@@ -19,6 +19,7 @@ const propTypes = {
     'secondary',
     'tertiary',
     'quaternary',
+    'action',
   ]),
   loading: PropTypes.bool,
   icon: PropTypes.node.isRequired,

--- a/src/shared-components/button/components/roundButton/style.js
+++ b/src/shared-components/button/components/roundButton/style.js
@@ -54,7 +54,8 @@ export const RoundButtonBase = styled(ButtonBase)`
 export const roundButtonLoader = disabled => css`
   width: 36px;
   margin: -3px -3px 0 0;
-  ${disabled && `
+  ${disabled &&
+    `
     & span {
       background-color: ${COLORS.white};
     }

--- a/src/shared-components/button/shared-components/loader/index.js
+++ b/src/shared-components/button/shared-components/loader/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import ButtonLoader from './style';
 
-const Loader = ({loading, disabled, buttonType, className, textColor }) => (
+const Loader = ({ loading, disabled, buttonType, className, textColor }) => (
   <ButtonLoader
     loading={loading}
     disabled={disabled}
@@ -27,10 +27,10 @@ Loader.propTypes = {
     'secondary',
     'tertiary',
     'quaternary',
+    'action',
   ]),
   className: PropTypes.string,
   textColor: PropTypes.string,
 };
 
 export default Loader;
-

--- a/src/shared-components/button/shared-components/loader/style.js
+++ b/src/shared-components/button/shared-components/loader/style.js
@@ -22,6 +22,10 @@ const quaternaryLoadingStyles = css`
   background-color: ${COLORS.purple70};
 `;
 
+const actionLoadingStyles = css`
+  background-color: ${COLORS.purple100};
+`;
+
 const ButtonLoader = styled.div`
   display: flex;
   align-items: center;
@@ -47,6 +51,8 @@ const ButtonLoader = styled.div`
           return accentLoadingStyles;
         case 'quaternary':
           return quaternaryLoadingStyles;
+        case 'action':
+          return actionLoadingStyles;
         default:
           return primaryLoadingStyles;
       }

--- a/src/shared-components/button/style.js
+++ b/src/shared-components/button/style.js
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { ANIMATION, COLORS, SPACING } from '../../constants';
+import { ANIMATION, COLORS, SPACING, BOX_SHADOWS } from '../../constants';
 
 const primaryStyles = css`
   background-color: ${COLORS.purple};
@@ -59,6 +59,19 @@ const quaternaryStyles = css`
   }
 `;
 
+const actionStyles = loading => css`
+  border-width: 1px;
+  border-color: ${COLORS.border};
+  background-color: ${COLORS.white};
+  color: ${COLORS.purple100};
+  fill: ${COLORS.purple100};
+  box-shadow: ${loading ? 'none' : BOX_SHADOWS.clickable};
+
+  &:hover {
+    box-shadow: ${loading ? 'none' : BOX_SHADOWS.clickableHover};
+  }
+`;
+
 const loadingStyles = css`
   cursor: not-allowed;
 
@@ -93,6 +106,8 @@ function parseTheme(disabled, buttonType, loading) {
       return tertiaryStyles;
     case 'quaternary':
       return quaternaryStyles;
+    case 'action':
+      return actionStyles(loading);
     default:
       return primaryStyles;
   }

--- a/src/shared-components/carousel/arrow/index.js
+++ b/src/shared-components/carousel/arrow/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { COLORS } from '../../../constants';
+import { RoundButton } from '../../button';
 import ArrowLeftIcon from '../../../svgs/icons/arrow-left-icon.svg';
 import ArrowRightIcon from '../../../svgs/icons/arrow-right-icon.svg';
 import ArrowContainer from './style';
@@ -24,14 +24,21 @@ class Arrow extends React.Component {
   render() {
     const { prev, next, disabled } = this.props;
     return (
-      <ArrowContainer
-        prev={prev}
-        next={next}
-        disabled={disabled}
-        onClick={this.arrowClickHandler}
-      >
-        {prev && <ArrowLeftIcon fill={COLORS.purple} />}
-        {next && <ArrowRightIcon fill={COLORS.purple} />}
+      <ArrowContainer prev={prev} next={next} disabled={disabled}>
+        {prev && (
+          <RoundButton
+            buttonType="action"
+            icon={<ArrowLeftIcon />}
+            onClick={this.arrowClickHandler}
+          />
+        )}
+        {next && (
+          <RoundButton
+            buttonType="action"
+            icon={<ArrowRightIcon />}
+            onClick={this.arrowClickHandler}
+          />
+        )}
       </ArrowContainer>
     );
   }

--- a/src/shared-components/carousel/arrow/style.js
+++ b/src/shared-components/carousel/arrow/style.js
@@ -1,28 +1,18 @@
 import styled from '@emotion/styled';
 
-import { SPACING, COLORS, ANIMATION, Z_SCALE } from '../../../constants';
+import { SPACING, Z_SCALE } from '../../../constants';
 
 const ArrowContainer = styled.div`
-  cursor: pointer;
   position: absolute;
   top: 50%;
   z-index: ${Z_SCALE.e2000};
-  padding: ${SPACING.small};
-  background-color: ${COLORS.white};
-  border-radius: 50%;
-  border: 1px solid ${COLORS.border};
-  transform: scale(1, 1) translate(0%, -50%);
-  transition: all ${ANIMATION.defaultTiming};
+  transform: translate(0%, -50%);
   display: block;
 
   ${({ prev }) => prev && `left: ${SPACING.xsmall};`};
   ${({ next }) => next && `right: ${SPACING.xsmall};`};
 
   ${({ disabled }) => disabled && `display: none;`};
-
-  &:hover {
-    transform: scale(1.1, 1.1) translate(0%, -50%);
-  }
 `;
 
 export default ArrowContainer;

--- a/src/shared-components/immersiveModal/index.js
+++ b/src/shared-components/immersiveModal/index.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { RoundButton } from '../button';
 import KEYCODES from '../../constants/keycodes';
 import keyPressMatch from '../../utils/keyPressMatch';
 import OffClickWrapper from '../offClickWrapper';
@@ -22,7 +23,7 @@ class ImmersiveModal extends React.Component {
     canBeClosed: PropTypes.bool,
     onClose: PropTypes.func,
     header: PropTypes.node,
-    width: PropTypes.oneOf(['small', 'medium'])
+    width: PropTypes.oneOf(['small', 'medium']),
   };
 
   static defaultProps = {
@@ -74,16 +75,18 @@ class ImmersiveModal extends React.Component {
   };
 
   render() {
-    const {
-      children, canBeClosed, onClose, header, width,
-    } = this.props;
+    const { children, canBeClosed, onClose, header, width } = this.props;
     return ReactDOM.createPortal(
       <Overlay>
         <ModalContainer maxWidth={width}>
           <OffClickWrapper onOffClick={this.closeModal}>
             {canBeClosed && (
-              <CloseIconContainer onClick={onClose}>
-                <CloseIcon />
+              <CloseIconContainer>
+                <RoundButton
+                  buttonType="action"
+                  icon={<CloseIcon />}
+                  onClick={onClose}
+                />
               </CloseIconContainer>
             )}
             {header}

--- a/src/shared-components/immersiveModal/style.js
+++ b/src/shared-components/immersiveModal/style.js
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import Typography from '../typography';
 import {
-  ANIMATION,
   BREAKPOINTS,
   COLORS,
   MEDIA_QUERIES,
@@ -40,20 +39,10 @@ export const ModalContainer = styled.div`
 `;
 
 export const CloseIconContainer = styled.div`
-  cursor: pointer;
   position: absolute;
   right: ${SPACING.small};
   top: ${SPACING.small};
-  transform: scale(1, 1);
-  transition: all ${ANIMATION.defaultTiming};
-  z-index: 2000;
-  padding: ${SPACING.small};
-  background-color: ${COLORS.white};
-  border-radius: 50%;
-
-  &:hover {
-    transform: scale(1.1, 1.1);
-  }
+  z-index: ${Z_SCALE.e2000};
 `;
 
 export const CopyContainer = styled.div`

--- a/src/shared-components/modal/index.js
+++ b/src/shared-components/modal/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import { Global } from '@emotion/core';
 
+import { RoundButton } from '../button';
 import CloseIcon from '../../svgs/icons/close-icon.svg';
 import keyPressMatch from '../../utils/keyPressMatch';
 import KEYCODES from '../../constants/keycodes';
@@ -118,8 +119,12 @@ class Modal extends React.Component {
           >
             <ModalBox isVisible={isVisible} onClick={this.stopPropagation}>
               {canBeClosed && (
-                <ModalCloseIcon onClick={this.closeModal}>
-                  <CloseIcon />
+                <ModalCloseIcon>
+                  <RoundButton
+                    buttonType="action"
+                    icon={<CloseIcon />}
+                    onClick={this.closeModal}
+                  />
                 </ModalCloseIcon>
               )}
               {children}

--- a/src/shared-components/modal/style.js
+++ b/src/shared-components/modal/style.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import Typography from '../typography';
-import { COLORS, MEDIA_QUERIES, SPACING } from '../../constants';
+import { COLORS, MEDIA_QUERIES, SPACING, Z_SCALE } from '../../constants';
 
 export const ModalOverlay = styled.div`
   -webkit-overflow-scrolling: touch;
@@ -38,19 +38,10 @@ export const ModalBox = styled.div`
 `;
 
 export const ModalCloseIcon = styled.div`
-  cursor: pointer;
-  opacity: 0.75;
   position: absolute;
   right: ${SPACING.small};
   top: ${SPACING.small};
-  transform: scale(1, 1);
-  transition: all 350ms;
-  z-index: 2000;
-
-  &:hover {
-    opacity: 1;
-    transform: scale(1.1, 1.1);
-  }
+  z-index: ${Z_SCALE.e2000};
 `;
 
 export const ContentContainer = styled.div`

--- a/stories/button/roundButton/index.js
+++ b/stories/button/roundButton/index.js
@@ -2,58 +2,125 @@ import React from 'react';
 import { text, select, boolean } from '@storybook/addon-knobs';
 import { withDocs } from 'storybook-readme';
 import { action } from '@storybook/addon-actions';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 import RoundButtonReadme from 'docs/button/roundButton.md';
 import { RoundButton, Typography } from 'src/shared-components';
-import { CheckmarkIcon, ArrowLeftIcon, ArrowRightIcon } from 'src/svgs/icons';
+import {
+  CheckmarkIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  CloseIcon,
+} from 'src/svgs/icons';
 import { SPACING } from 'src/constants';
 
+const MainContainer = styled.div`
+  text-align: left;
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
+  align-items: center;
+  margin: ${SPACING.base} 0 ${SPACING.large};
+`;
+
 const RoundButtonStory = withDocs(RoundButtonReadme, () => (
-  <React.Fragment>
-    <RoundButton.Container multi>
+  <MainContainer>
+    <Typography.Title>Default</Typography.Title>
+    <ButtonsContainer>
       <RoundButton icon={<CheckmarkIcon />}>Primary</RoundButton>
+
       <RoundButton buttonType="secondary" icon={<ArrowRightIcon />}>
-          Secondary
+        Secondary
       </RoundButton>
-    </RoundButton.Container>
-    <RoundButton.Container multi>
+
       <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />}>
-          Tertiary
+        Tertiary
       </RoundButton>
+
       <RoundButton buttonType="quaternary" icon={<ArrowRightIcon />}>
-          Quaternary
+        Quaternary
       </RoundButton>
-    </RoundButton.Container>
 
-    <RoundButton.Container multi>
+      <RoundButton buttonType="action" icon={<CloseIcon />}>
+        Action
+      </RoundButton>
+    </ButtonsContainer>
+
+    <Typography.Title>Disabled</Typography.Title>
+    <ButtonsContainer>
+      <RoundButton icon={<ArrowLeftIcon />} disabled>
+        Primary
+      </RoundButton>
+
+      <RoundButton buttonType="secondary" icon={<ArrowRightIcon />} disabled>
+        Secondary
+      </RoundButton>
+
       <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} disabled>
-          Disabled
+        Tertiary
       </RoundButton>
-    </RoundButton.Container>
-    <RoundButton.Container multi>
+
+      <RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} disabled>
+        Quaternary
+      </RoundButton>
+
+      <RoundButton buttonType="action" icon={<CloseIcon />} disabled>
+        Action
+      </RoundButton>
+    </ButtonsContainer>
+
+    <Typography.Title>Loading</Typography.Title>
+    <ButtonsContainer>
       <RoundButton icon={<ArrowLeftIcon />} loading>
-          Primary Loading
+        Primary
       </RoundButton>
+
       <RoundButton buttonType="secondary" icon={<ArrowRightIcon />} loading>
-          Secondary Loading
+        Secondary
       </RoundButton>
-    </RoundButton.Container>
-    <RoundButton.Container multi>
+
       <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} loading>
-          Tertiary Loading
+        Tertiary
       </RoundButton>
+
       <RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} loading>
-          Quaternary Loading
+        Quaternary
       </RoundButton>
+
+      <RoundButton buttonType="action" icon={<CloseIcon />} loading>
+        Action
+      </RoundButton>
+    </ButtonsContainer>
+
+    <Typography.Title>
+      Within RoundButton.Container (with multi prop)
+    </Typography.Title>
+    <RoundButton.Container
+      multi
+      css={css`
+        margin: ${SPACING.medium} 0;
+      `}
+    >
+      <RoundButton icon={<ArrowLeftIcon />} />
+      <RoundButton icon={<ArrowRightIcon />} />
     </RoundButton.Container>
 
-    <Typography.Heading css={css`text-align: left; padding: ${SPACING.base} 0 ${SPACING.small};`}>
-        With Knobs
-    </Typography.Heading>
-    <RoundButton.Container>
+    <Typography.Title>With Knobs</Typography.Title>
+    <ButtonsContainer
+      css={css`
+        max-width: 100px;
+      `}
+    >
       <RoundButton
-        buttonType={select('buttonType', ['primary', 'secondary', 'tertiary', 'quaternary'], 'primary')}
+        buttonType={select(
+          'buttonType',
+          ['primary', 'secondary', 'tertiary', 'quaternary', 'action'],
+          'primary'
+        )}
         loading={boolean('loading', false)}
         disabled={boolean('disabled', false)}
         onClick={action('button clicked')}
@@ -62,8 +129,8 @@ const RoundButtonStory = withDocs(RoundButtonReadme, () => (
       >
         {text('children', 'Click me!')}
       </RoundButton>
-    </RoundButton.Container>
-  </React.Fragment>
+    </ButtonsContainer>
+  </MainContainer>
 ));
 
 export default RoundButtonStory;


### PR DESCRIPTION
In this PR:
- Added `action` option to buttonType prop
- Redesigned the docs 
- Ben I added `clickable` and `clickableHover` to the action button
- Make disabled and loading work for new action button

**NEW**
- Refactor Carousel/Modal/ImmersiveModal . to use this new `action` RoundButton