### PR TITLE
added `content` prop type to alert component

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -3,7 +3,11 @@
 
 ```jsx
 import { Alert } from 'radiance-ui';
-const SampleContentComponent = () => <div>Click <a href='https://google.com'>here</a> to go to Google!</div>;
+const SampleContentComponent = () => (
+  <div>
+    Click <a href="https://google.com">here</a> to go to Google!
+  </div>
+);
 
 <Alert.Container>
   <Alert
@@ -31,7 +35,7 @@ const SampleContentComponent = () => <div>Click <a href='https://google.com'>her
     onExit={() => {}}
   />
   <Alert
-	content= <SampleContentComponent/>
+    content={<SampleContentComponent />}
     type="success"
     duration="sticky"
     onExit={() => {}}

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -3,6 +3,7 @@
 
 ```jsx
 import { Alert } from 'radiance-ui';
+const SampleContentComponent = () => (<div>Your info is updated!  <a href='http://google.com'> Click here to see changes</a></div>);
 
 <Alert.Container>
   <Alert
@@ -29,18 +30,25 @@ import { Alert } from 'radiance-ui';
     duration="sticky"
     onExit={() => {}}
   />
+  <Alert
+	content=<SampleContentComponent/>
+    type="success"
+    duration="sticky"
+    onExit={() => {}}
+  />  
 </Alert.Container>
 ```
 
 <!-- STORY -->
 
 ### Proptypes
-| prop     | propType           | required | default | description                                                                                                                  |
-|----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| text     | string             | yes      | -       | alert text to be displayed                                                                                                   |
-| type     | string             | yes      | -       | must be one of: 'success', 'danger', 'info'                                                                                  |
-| duration | number&#124;string | yes      | -       | can be 'sticky' or number in seconds before the alert is dismissed                                                           |
-| onExit   | func               | yes      | -       | callback function called on dismissal of  the alert. The function will receive all  of the component's props as the argument |
+| prop     | propType                                | required                    | default | description                                                                                                                  |
+|----------|-----------------------------------------|-----------------------------|---------|------------------------------------------------------------------------------------------------------------------------------|
+| text     | string         				         | yes if content prop is empty| -       | alert text to be displayed. Will be deprecated in next major version                                                                                                  |
+| content  | numbers, strings, elements or an array  | yes if text prop is empty   | -       | renders anything passed to component. In future changes alert text.                                                          |
+| type     | string             				     | yes                         | -       | must be one of: 'success', 'danger', 'info'                                                                                  |
+| duration | number&#124;string					     | yes                         | -       | can be 'sticky' or number in seconds before the alert is dismissed                                                           |
+| onExit   | func            					     | yes                         | -       | callback function called on dismissal of  the alert. The function will receive all  of the component's props as the argument |
 
 ### Notes
 The `<Alert />` component provides only the styling for and enter/exit

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -3,35 +3,35 @@
 
 ```jsx
 import { Alert } from 'radiance-ui';
-const SampleContentComponent = () => (<div>Your info is updated!  <a href='http://google.com'> Click here to see changes</a></div>);
+const SampleContentComponent = () => <div>Click <a href='https://google.com'>here</a> to go to Google!</div>;
 
 <Alert.Container>
   <Alert
-    text="Your photos were uploaded successfully!"
+    content="Your photos were uploaded successfully!"
     type="success"
     duration={4}
     onExit={() => {}}
   />
   <Alert
-    text="Your photos were uploaded successfully!"
+    content="Your photos were uploaded successfully!"
     type="success"
     duration="sticky"
     onExit={() => {}}
   />
   <Alert
-    text="Support has been notified."
+    content="Support has been notified."
     type="info"
     duration="sticky"
     onExit={() => {}}
   />
   <Alert
-    text="Oops! We couldn't update your information!"
+    content="Oops! We couldn't update your information!"
     type="danger"
     duration="sticky"
     onExit={() => {}}
   />
   <Alert
-	content=<SampleContentComponent/>
+	content= <SampleContentComponent/>
     type="success"
     duration="sticky"
     onExit={() => {}}
@@ -45,7 +45,7 @@ const SampleContentComponent = () => (<div>Your info is updated!  <a href='http:
 | prop     | propType                                | required                    | default | description                                                                                                                  |
 |----------|-----------------------------------------|-----------------------------|---------|------------------------------------------------------------------------------------------------------------------------------|
 | text     | string         				         | yes if content prop is empty| -       | alert text to be displayed. Will be deprecated in next major version                                                                                                  |
-| content  | numbers, strings, elements or an array  | yes if text prop is empty   | -       | renders anything passed to component. In future changes alert text.                                                          |
+| content  | numbers, strings, elements or an array  | yes if text prop is empty   | -       | renders anything passed to component as text displayed in alert.                                                          |
 | type     | string             				     | yes                         | -       | must be one of: 'success', 'danger', 'info'                                                                                  |
 | duration | number&#124;string					     | yes                         | -       | can be 'sticky' or number in seconds before the alert is dismissed                                                           |
 | onExit   | func            					     | yes                         | -       | callback function called on dismissal of  the alert. The function will receive all  of the component's props as the argument |

--- a/src/shared-components/alert/__snapshots__/test.js.snap
+++ b/src/shared-components/alert/__snapshots__/test.js.snap
@@ -518,6 +518,187 @@ exports[`Alert UI snapshots renders info type and text 1`] = `
 </div>
 `;
 
+exports[`Alert UI snapshots renders info type with text prop 1`] = `
+@keyframes animation-0 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0,-24px,0);
+    -ms-transform: translate3d(0,-24px,0);
+    transform: translate3d(0,-24px,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0px,0);
+    -ms-transform: translate3d(0,0px,0);
+    transform: translate3d(0,0px,0);
+  }
+}
+
+@keyframes animation-0 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0,-24px,0);
+    -ms-transform: translate3d(0,-24px,0);
+    transform: translate3d(0,-24px,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0px,0);
+    -ms-transform: translate3d(0,0px,0);
+    transform: translate3d(0,0px,0);
+  }
+}
+
+@keyframes animation-0 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0,-24px,0);
+    -ms-transform: translate3d(0,-24px,0);
+    transform: translate3d(0,-24px,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0px,0);
+    -ms-transform: translate3d(0,0px,0);
+    transform: translate3d(0,0px,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(24px,0,0);
+    -ms-transform: translate3d(24px,0,0);
+    transform: translate3d(24px,0,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(24px,0,0);
+    -ms-transform: translate3d(24px,0,0);
+    transform: translate3d(24px,0,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(24px,0,0);
+    -ms-transform: translate3d(24px,0,0);
+    transform: translate3d(24px,0,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 1.5rem 0 1rem;
+  width: 100%;
+}
+
+.emotion-0 {
+  margin: 2.5px 1rem 0px 0px;
+  min-height: 1rem;
+  min-width: 1rem;
+}
+
+.emotion-3 {
+  -webkit-animation: animation-0 350ms 1;
+  animation: animation-0 350ms 1;
+  border-width: 1px;
+  border-style: solid;
+  box-shadow: 0 12px 20px 0 rgba(45,45,48,0.05);
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  margin: 0 auto 0.5rem;
+  opacity: 1;
+  padding: 11px 0px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  text-align: left;
+  -webkit-transform: translate3d(0,0,0);
+  -ms-transform: translate3d(0,0,0);
+  transform: translate3d(0,0,0);
+  -webkit-transition: 350ms;
+  transition: 350ms;
+  width: 327px;
+  background-color: #ededf0;
+  border-color: #e1e0e6;
+  color: #706D87;
+  fill: #706D87;
+}
+
+@media (min-width:992px) {
+  .emotion-3 {
+    -webkit-animation: animation-1 350ms 1;
+    animation: animation-1 350ms 1;
+    font-size: 0.875rem;
+    margin-bottom: 1rem;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+<div
+  className="emotion-3 emotion-4"
+  onClick={[Function]}
+>
+  <div
+    className="emotion-1 emotion-2"
+  >
+    <svg
+      className="emotion-0"
+      fill="currentColor"
+    />
+    Your email address was updated successfully!
+  </div>
+</div>
+`;
+
 exports[`Alert UI snapshots renders success type and text 1`] = `
 @keyframes animation-0 {
   from {

--- a/src/shared-components/alert/__snapshots__/test.js.snap
+++ b/src/shared-components/alert/__snapshots__/test.js.snap
@@ -1,5 +1,193 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Alert UI snapshots renders custom component passed in content prop 1`] = `
+@keyframes animation-0 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0,-24px,0);
+    -ms-transform: translate3d(0,-24px,0);
+    transform: translate3d(0,-24px,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0px,0);
+    -ms-transform: translate3d(0,0px,0);
+    transform: translate3d(0,0px,0);
+  }
+}
+
+@keyframes animation-0 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0,-24px,0);
+    -ms-transform: translate3d(0,-24px,0);
+    transform: translate3d(0,-24px,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0px,0);
+    -ms-transform: translate3d(0,0px,0);
+    transform: translate3d(0,0px,0);
+  }
+}
+
+@keyframes animation-0 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0,-24px,0);
+    -ms-transform: translate3d(0,-24px,0);
+    transform: translate3d(0,-24px,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0px,0);
+    -ms-transform: translate3d(0,0px,0);
+    transform: translate3d(0,0px,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(24px,0,0);
+    -ms-transform: translate3d(24px,0,0);
+    transform: translate3d(24px,0,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(24px,0,0);
+    -ms-transform: translate3d(24px,0,0);
+    transform: translate3d(24px,0,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(24px,0,0);
+    -ms-transform: translate3d(24px,0,0);
+    transform: translate3d(24px,0,0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+.emotion-3 {
+  -webkit-animation: animation-0 350ms 1;
+  animation: animation-0 350ms 1;
+  border-width: 1px;
+  border-style: solid;
+  box-shadow: 0 12px 20px 0 rgba(45,45,48,0.05);
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  margin: 0 auto 0.5rem;
+  opacity: 1;
+  padding: 11px 0px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  text-align: left;
+  -webkit-transform: translate3d(0,0,0);
+  -ms-transform: translate3d(0,0,0);
+  transform: translate3d(0,0,0);
+  -webkit-transition: 350ms;
+  transition: 350ms;
+  width: 327px;
+  background-color: #EAF1EB;
+  border-color: #DFE9E0;
+  color: #2B6E33;
+  fill: #2B6E33;
+}
+
+@media (min-width:992px) {
+  .emotion-3 {
+    -webkit-animation: animation-1 350ms 1;
+    animation: animation-1 350ms 1;
+    font-size: 0.875rem;
+    margin-bottom: 1rem;
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+}
+
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 1.5rem 0 1rem;
+  width: 100%;
+}
+
+.emotion-0 {
+  margin: 2.5px 1rem 0px 0px;
+  min-height: 1rem;
+  min-width: 1rem;
+}
+
+<div
+  className="emotion-3 emotion-4"
+  onClick={[Function]}
+>
+  <div
+    className="emotion-1 emotion-2"
+  >
+    <svg
+      className="emotion-0"
+      fill="currentColor"
+    />
+    <div>
+      Your info is updated!  
+      <a
+        href="http://google.com"
+      >
+         Click here to see changes
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Alert UI snapshots renders danger type and text 1`] = `
 @keyframes animation-0 {
   from {

--- a/src/shared-components/alert/index.js
+++ b/src/shared-components/alert/index.js
@@ -11,6 +11,7 @@ import {
   AlertContentContainer,
   alertIconStyles,
 } from './style';
+import withDeprecationWarning from '../../utils/withDeprecationWarning'
 
 const ANIMATION_DELAY = 500;
 
@@ -20,13 +21,26 @@ const alertIconMapping = {
   info: InfoIcon,
 };
 
+const deprecatedProperties = {
+  text: 'text Prop is deprecated. Use content instead',
+}
+
+const contentOrTextHaveToBeFilled = (props, propName, componentName) =>{
+  if ((!props[propName] || typeof(props[propName])) !== 'string' && ( !props.content || props.content == undefined)) {
+    return new Error(
+      `You need to pass either 'content' or 'text' prop to '${componentName}' component. Prop 'text' will be deprecated with next major version`
+    );
+  }
+}
+
 class Alert extends React.Component {
   static Container = ({ children }) => (
     <AlertsContainer>{children}</AlertsContainer>
   );
 
   static propTypes = {
-    text: PropTypes.string.isRequired,
+    text: contentOrTextHaveToBeFilled,
+    content: PropTypes.node,
     type: PropTypes.oneOf(['success', 'danger', 'info']).isRequired,
     duration: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
       .isRequired,
@@ -72,7 +86,7 @@ class Alert extends React.Component {
   };
 
   render() {
-    const { text, type, onExit, ...rest } = this.props;
+    const { text, content, type, onExit, ...rest } = this.props;
     const { exiting, exited } = this.state;
     const Icon = alertIconMapping[type];
 
@@ -94,11 +108,11 @@ class Alert extends React.Component {
             `}
             fill="currentColor"
           />
-          {text}
+          {content || text}
         </AlertContentContainer>
       </AlertContainer>
     );
   }
 }
 
-export default Alert;
+export default withDeprecationWarning(Alert, deprecatedProperties);

--- a/src/shared-components/alert/test.js
+++ b/src/shared-components/alert/test.js
@@ -15,7 +15,7 @@ describe('Alert UI snapshots', () => {
   test('renders success type and text', () => {
     const component = renderer.create(
       <Alert
-        text={testAlert.text}
+        content={testAlert.text}
         type="success"
         duration={testAlert.duration}
         onExit={() => { }}
@@ -29,7 +29,7 @@ describe('Alert UI snapshots', () => {
   test('renders danger type and text', () => {
     const component = renderer.create(
       <Alert
-        text={testAlert.text}
+        content={testAlert.text}
         type="danger"
         duration={testAlert.duration}
         onExit={() => { }}
@@ -43,7 +43,7 @@ describe('Alert UI snapshots', () => {
   test('renders info type and text', () => {
     const component = renderer.create(
       <Alert
-        text={testAlert.text}
+        content={testAlert.text}
         type="info"
         duration={testAlert.duration}
         onExit={() => { }}
@@ -59,6 +59,20 @@ describe('Alert UI snapshots', () => {
       <Alert
         content= {<SampleContentComponent />}
         type="success"
+        duration={testAlert.duration}
+        onExit={() => { }}
+      />
+    );
+
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders info type with text prop', () => {
+    const component = renderer.create(
+      <Alert
+        text={testAlert.text}
+        type="info"
         duration={testAlert.duration}
         onExit={() => { }}
       />

--- a/src/shared-components/alert/test.js
+++ b/src/shared-components/alert/test.js
@@ -9,6 +9,7 @@ const testAlert = {
   type: 'success',
   duration: 'sticky',
 };
+const SampleContentComponent = () => (<div>Your info is updated!  <a href='http://google.com'> Click here to see changes</a></div>);
 
 describe('Alert UI snapshots', () => {
   test('renders success type and text', () => {
@@ -44,6 +45,20 @@ describe('Alert UI snapshots', () => {
       <Alert
         text={testAlert.text}
         type="info"
+        duration={testAlert.duration}
+        onExit={() => { }}
+      />
+    );
+
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders custom component passed in content prop', () => {
+    const component = renderer.create(
+      <Alert
+        content= {<SampleContentComponent />}
+        type="success"
         duration={testAlert.duration}
         onExit={() => { }}
       />

--- a/stories/alert/index.js
+++ b/stories/alert/index.js
@@ -7,7 +7,7 @@ import AlertReadme from 'docs/alert.md';
 import { Alert, Typography } from 'src/shared-components';
 
 const stories = storiesOf('Alert', module);
-const SampleContentComponent = () => (<div>Your info is updated!  <a href='http://google.com'> Click here to see changes</a></div>);
+const SampleContentComponent = () => <div>Click <a href='https://google.com'>here</a> to go to Google!</div>;
 stories.addDecorator(withKnobs);
 
 stories.add(
@@ -16,31 +16,31 @@ stories.add(
     <React.Fragment>
       <Alert.Container>
         <Alert
-          text="Your photos were uploaded successfully!"
+          content="Your photos were uploaded successfully!"
           type="success"
           duration={4}
           onExit={() => { }}
         />
         <Alert
-          text="Your photos were uploaded successfully!"
+          content="Your photos were uploaded successfully!"
           type="success"
           duration="sticky"
           onExit={() => { }}
         />
         <Alert
-          text="Support has been notified."
+          content="Support has been notified."
           type="info"
           duration="sticky"
           onExit={() => { }}
         />
         <Alert
-          text="Oops! We couldn't update your information!"
+          content="Oops! We couldn't update your information!"
           type="danger"
           duration="sticky"
           onExit={() => { }}
         />
         <Alert
-          content=<SampleContentComponent />
+          content= <SampleContentComponent />
           type="success"
           duration="sticky"
           onExit={() => { }}

--- a/stories/alert/index.js
+++ b/stories/alert/index.js
@@ -7,7 +7,7 @@ import AlertReadme from 'docs/alert.md';
 import { Alert, Typography } from 'src/shared-components';
 
 const stories = storiesOf('Alert', module);
-
+const SampleContentComponent = () => (<div>Your info is updated!  <a href='http://google.com'> Click here to see changes</a></div>);
 stories.addDecorator(withKnobs);
 
 stories.add(
@@ -36,6 +36,12 @@ stories.add(
         <Alert
           text="Oops! We couldn't update your information!"
           type="danger"
+          duration="sticky"
+          onExit={() => { }}
+        />
+        <Alert
+          content=<SampleContentComponent />
+          type="success"
           duration="sticky"
           onExit={() => { }}
         />

--- a/stories/alert/index.js
+++ b/stories/alert/index.js
@@ -3,11 +3,17 @@ import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
+
 import AlertReadme from 'docs/alert.md';
 import { Alert, Typography } from 'src/shared-components';
 
 const stories = storiesOf('Alert', module);
-const SampleContentComponent = () => <div>Click <a href='https://google.com'>here</a> to go to Google!</div>;
+const SampleContentComponent = () => (
+  <div>
+    Click <a href="https://google.com">here</a> to go to Google!
+  </div>
+);
+
 stories.addDecorator(withKnobs);
 
 stories.add(
@@ -19,38 +25,38 @@ stories.add(
           content="Your photos were uploaded successfully!"
           type="success"
           duration={4}
-          onExit={() => { }}
+          onExit={() => {}}
         />
         <Alert
           content="Your photos were uploaded successfully!"
           type="success"
           duration="sticky"
-          onExit={() => { }}
+          onExit={() => {}}
         />
         <Alert
           content="Support has been notified."
           type="info"
           duration="sticky"
-          onExit={() => { }}
+          onExit={() => {}}
         />
         <Alert
           content="Oops! We couldn't update your information!"
           type="danger"
           duration="sticky"
-          onExit={() => { }}
+          onExit={() => {}}
         />
         <Alert
-          content= <SampleContentComponent />
+          content={<SampleContentComponent />}
           type="success"
           duration="sticky"
-          onExit={() => { }}
+          onExit={() => {}}
         />
       </Alert.Container>
       <Typography.Heading>With Knobs</Typography.Heading>
       <Alert
         text={text('text', 'This is an alert')}
         type={select('type', ['success', 'info', 'danger'], 'info')}
-        duration='sticky'
+        duration="sticky"
         onExit={action('alert exited')}
       />
     </React.Fragment>


### PR DESCRIPTION
`content` prop type is PropTypes.node so this component can accept any kind of content. This is implemented because of need to pass links inside alert component.
added custom prop check to make sure one of the props(text/content) is passed to component, this can be removed after text deprecation
added deprecationWarning for Alert component
updated alert.md with `content` prop
updated storied/alert with sample of alert component with `content` prop

![Screen Shot 2019-05-20 at 8 07 21 PM](https://user-images.githubusercontent.com/50116304/58042408-eada3780-7b3a-11e9-9f48-f3d608bc05d0.png)