### PR TITLE
added legal pages as reusable components

### DIFF
--- a/src/shared-components/index.js
+++ b/src/shared-components/index.js
@@ -2,6 +2,7 @@ export { default as Accordion } from './accordion';
 export { default as Alert } from './alert';
 export { default as Avatar } from './avatar';
 export { default as Banner } from './banner';
+export { default as BulkErrors } from './bulkErrors';
 export {
   default as Button,
   RoundButton,
@@ -14,8 +15,8 @@ export { default as Chip } from './chip';
 export { default as Container } from './container';
 export { default as Dropdown } from './dropdown';
 export { default as Field } from './field';
-export { default as BulkErrors } from './bulkErrors';
 export { default as ImmersiveModal } from './immersiveModal';
+export * from './legalComponents';
 export { default as LoadingSpinner } from './loadingSpinner';
 export { default as Modal } from './modal';
 export { default as OffClickWrapper } from './offClickWrapper';

--- a/src/shared-components/legalComponents/disclaimer/index.js
+++ b/src/shared-components/legalComponents/disclaimer/index.js
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { LegalContainer } from '../style';
+
+const Disclaimer = () => (
+  <LegalContainer>
+    <h1>Disclaimer</h1>
+    <time dateTime="2019-01-09">Last Updated: January 9, 2019</time>
+    <p>
+      Please review our{' '}
+      <a href="/terms" target="_blank" rel="noopener noreferrer">
+        Terms of Service
+      </a>{' '}
+      for all disclaimers of our liability, which include:
+    </p>
+    <ul>
+      <li>
+        Curology, Inc. provides technological and other services to connect
+        patients to licensed medical providers.
+      </li>
+      <li>
+        All medical care and prescription products are provided licensed
+        providers.
+      </li>
+      <li>Curology, Inc. does not provide any medical services.</li>
+      <li>
+        All customized prescription medications are produced and shipped by
+        licensed professionals directly to patients.
+      </li>
+      <li>
+        Curology will send you email correspondence that may contain details of
+        your treatment. These emails will never contain your photos or payment
+        information. We will never request that you email us any health
+        information or payment information.
+      </li>
+      <li>
+        Curology is exclusively for the diagnosis and treatment of acne and skin
+        aging (and related conditions), and not for any other medical or
+        dermatological conditions.
+      </li>
+      <li>
+        Curology’s affiliated medical providers do not provide screening for
+        skin cancer or for any other conditions aside from acne and skin aging.
+      </li>
+      <li>
+        Curology does not replace your existing relationship with your primary
+        care physician.
+      </li>
+      <li>Curology is not for emergencies.</li>
+      <li>Curology is not an insurance product.</li>
+      <li>
+        Curology and its affiliated medical professionals operate subject to
+        state regulation and may not be available in certain states.
+      </li>
+      <li>Curology does not guarantee that a prescription will be written.</li>
+      <li>
+        Curology’s affiliated medical providers do not prescribe DEA controlled
+        substances.
+      </li>
+      <li>
+        Curology does not cover the cost of any prescription pills that may be
+        prescribed in addition to your customized prescription cream.
+      </li>
+      <li>
+        Curology’s affiliated medical providers reserve the right to deny
+        treatment if they believe that a patient may be better served by a local
+        provider, or for any other reason according to their professional
+        judgment.
+      </li>
+    </ul>
+  </LegalContainer>
+);
+
+export default Disclaimer;

--- a/src/shared-components/legalComponents/index.js
+++ b/src/shared-components/legalComponents/index.js
@@ -1,0 +1,6 @@
+export { LegalContainer } from './style';
+export { default as TermsOfService } from '../termsOfService';
+export { default as PrivacyPolicy } from '../privacyPolicy';
+export { default as Disclaimer } from '../disclaimer';
+export { default as TelehealthConsent } from '../telehealthConsent';
+export { default as ParentGuardianTelehealthConsent } from '../parentGuardianTelehealthConsent';

--- a/src/shared-components/legalComponents/index.js
+++ b/src/shared-components/legalComponents/index.js
@@ -1,6 +1,6 @@
 export { LegalContainer } from './style';
-export { default as TermsOfService } from '../termsOfService';
-export { default as PrivacyPolicy } from '../privacyPolicy';
-export { default as Disclaimer } from '../disclaimer';
-export { default as TelehealthConsent } from '../telehealthConsent';
-export { default as ParentGuardianTelehealthConsent } from '../parentGuardianTelehealthConsent';
+export { default as TermsOfService } from './termsOfService';
+export { default as PrivacyPolicy } from './privacyPolicy';
+export { default as Disclaimer } from './disclaimer';
+export { default as TelehealthConsent } from './telehealthConsent';
+export { default as ParentGuardianTelehealthConsent } from './parentGuardianTelehealthConsent';

--- a/src/shared-components/legalComponents/parentGuardianTelehealthConsent/index.js
+++ b/src/shared-components/legalComponents/parentGuardianTelehealthConsent/index.js
@@ -1,0 +1,112 @@
+import React from 'react';
+
+import { LegalContainer } from '../style';
+
+const ParentGuardianTelehealthConsent = () => (
+  <LegalContainer>
+    <h1>Parent/Guardian Consent to Treatment via Telehealth</h1>
+    <time dateTime="2019-01-09">Last Updated: February 15, 2019</time>
+    <ol>
+      <li>
+        I am the parent or legal guardian of someone under 18 years of age
+        (“Minor”) seeking treatment via telehealth. The person being treated
+        pursuant to this Consent to Treatment via Telehealth is referred to as
+        the “Patient”.
+      </li>
+      <li>
+        I understand that Curology, Inc.’s affiliated healthcare providers
+        (“healthcare provider”) treat patients via telehealth, and I wish for
+        the Minor to be treated via telehealth. I understand that the telehealth
+        treatment may involve all of the following (collectively “telehealth
+        visit”):
+        <ul>
+          <li>
+            Electronic creation and transmission of medical records, photo
+            images, personal health information, or other data between me and or
+            the Minor as the Patient and healthcare providers and among
+            healthcare providers and entities; and
+          </li>
+          <li>
+            Interactions between me and or the Minor as the Patient and a
+            healthcare provider via data communications (including store and
+            forward technology); and
+          </li>
+        </ul>
+      </li>
+      <li>
+        I understand there are potential risks to a telehealth visit, including
+        interruptions, unauthorized access which could disclose health
+        information, and technical difficulties. I understand that I, the
+        healthcare provider or the Patient can discontinue the treatment via
+        telehealth visit if it is felt that the situation warrants.
+      </li>
+      <li>
+        I understand that Patient information as part of the telehealth visit
+        may be shared with other individuals or entities for technological and
+        billing purposes and any information collected by a healthcare provider
+        as part of this telehealth visit will be used for analyzing the
+        patient’s health, possible treatments, to conduct follow-up activities
+        with the Patient, including to offer other Curology products and
+        services to the Patient, and will be used further as stated in the
+        Curology{' '}
+        <a href="/privacy" target="_blank" rel="noopener noreferrer">
+          Privacy Policy
+        </a>
+        .
+      </li>
+      <li>
+        I understand that Patient care at Curology is limited to the diagnosis
+        and treatment of acne and skin aging and related disorders and not for
+        the diagnosis or treatment of any other medical or dermatological
+        conditions, including skin cancer. I understand that the Website is not
+        a substitute for the in-person treatment or advice of the Patient’s
+        local dermatologist, primary care physician, or any other qualified
+        healthcare professional. I understand that the Patient should never
+        delay seeking advice from the Patient’s local dermatologist, primary
+        care physician, or any other health professionals if advised to do so by
+        the Patient’s Curology healthcare provider, or if the Patient has any
+        concerns.
+      </li>
+      <li>
+        I understand that Curology undertakes no obligation to review the
+        inactive ingredients and or the base ingredients in any product that is
+        recommended or sold to the Patient, including, without limitation, to
+        ascertain that Patient is not allergic to such inactive or base
+        ingredients. I further understand that it is solely the Patient’s (or
+        the Patient’s legal guardian’s) responsibility to review those
+        ingredients, as listed on the Curology website.
+      </li>
+      <li>
+        I understand that if the Patient has an emergency health issue of any
+        nature, the Patient (or the Patient’s legal guardian) should call local
+        emergency medical number or take such other action as necessary.
+      </li>
+      <li>
+        I understand that I have the right to request that the Medical Record
+        established with Curology be sent to my primary healthcare provider. I
+        may request this on my{' '}
+        <a
+          href="/app/dashboard/request-medical-record"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          dashboard
+        </a>
+        .
+      </li>
+    </ol>
+    <p>By continuing, I represent:</p>
+    <ul>
+      <li>
+        That I have read or had this form read and/or had this form explained to
+        me.
+      </li>
+      <li>
+        That I fully understand its contents, including the risks and benefits
+        of the telehealth service provided through Curology’s affiliates.
+      </li>
+    </ul>
+  </LegalContainer>
+);
+
+export default ParentGuardianTelehealthConsent;

--- a/src/shared-components/legalComponents/privacyPolicy/index.js
+++ b/src/shared-components/legalComponents/privacyPolicy/index.js
@@ -1,0 +1,494 @@
+import React from 'react';
+
+import { LegalContainer } from '../style';
+
+const PrivacyPolicy = () => (
+  <LegalContainer>
+    <h1>Privacy Policy</h1>
+    <time dateTime="2019-04-25">Last Updated: April 25, 2019</time>
+    <p>
+      Curology understands that your personal information, including your health
+      information, is important to you. Therefore, we have developed this
+      privacy and security policy (this “Privacy Policy”) to describe how your
+      personal information may be collected, used and disclosed by Curology,
+      Inc. and its subsidiaries and affiliates, including the medical practices
+      and other healthcare entities with which Curology contracts in order to
+      provide products and services to you, (collectively, “Curology,” “we”,
+      “us”, or “our”). This Privacy Policy applies to websites and/or mobile
+      applications (collectively, the “Website” or “Websites”), and/or other
+      digital services (including our social media pages) or email messages
+      (collectively, the “Products”), that are offered or operated by Curology
+      and in which this Privacy Policy is posted or linked.
+    </p>
+    <p>
+      By using our Websites, purchasing and/or using our Products, and/or
+      providing your personal information to Curology, you acknowledge this
+      Privacy Policy, whether or not you register for an account with Curology
+      through the Website (an “Account,” and collectively with the Websites and
+      the Products, the “Services”).
+    </p>
+    <p>
+      PLEASE REVIEW THIS PRIVACY POLICY CAREFULLY.{' '}
+      <b>
+        IF YOU DO NOT AGREE WITH ANY PROVISION IN THIS PRIVACY POLICY, PLEASE DO
+        NOT USE THE WEBSITE, PURCHASE OR USE THE PRODUCTS, PROVIDE YOUR PERSONAL
+        INFORMATION TO CUROLOGY, OR REGISTER FOR AN ACCOUNT.
+      </b>
+    </p>
+    <p>
+      This Privacy Policy does not apply to websites or applications that do not
+      link or display this Privacy Policy or that display or link to different
+      privacy policies. In addition to this Privacy Policy, Curology has
+      established Terms of Service that set forth the general rules and policies
+      governing your use of the Website. Please review the Terms of Service
+      carefully since they contain provisions that limit Curology’s liability to
+      your use of the Website and Products.
+    </p>
+    <p>
+      A copy of the Terms of Service can be found{' '}
+      <a href="/terms" target="_blank" rel="noopener noreferrer">
+        here
+      </a>
+      .
+    </p>
+    <h2>The Personal Information We Collect Through the Services</h2>
+    <p>
+      In connection with the Services, Curology will collect, use and disclose
+      Personal Information as described below.
+    </p>
+    <p>
+      “Personal Information,” as used in this Privacy Policy, means information
+      associated with or used to identify or contact a specific person. Personal
+      Information we collect may include, but is not limited to, contact
+      information, including, name, email address, mailing address, phone
+      number, age, and gender.
+    </p>
+    <p>
+      Personal Information also includes certain “Sensitive Personal
+      Information” as may be defined under federal or state law, or as otherwise
+      set forth in Curology’s policies. Sensitive Personal Information may be
+      subject to stricter regulation and consent requirements than other
+      information. Before providing Sensitive Personal Information to us in any
+      manner, including through our Services, you should carefully consider
+      whether to disclose such Sensitive Personal Information. Sensitive
+      Personal Information that we may collect includes, but is not limited to,
+      location data, health information (including medical records), health
+      background, health status, prescribed and over-the-counter medications,
+      medical ID numbers, driver’s license numbers, laboratory testing results,
+      and full-face and similarly identifiable photos.
+    </p>
+    <p>
+      If you submit any Personal Information to us relating to other people in
+      connection with the Services, you represent that you have the authority to
+      do so and that you permit us to use the information in accordance with
+      this Privacy Policy.
+    </p>
+    <h3>Our Use of Personal Information</h3>
+    <p>
+      Any Personal Information you provide to us when you visit or use the
+      Services is voluntary. However, in order to utilize certain Services, you
+      may need to provide Personal Information and/or Sensitive Personal
+      Information.
+    </p>
+    <p>
+      Subject to the restrictions on the use and disclosure of your Personal
+      Information under applicable law, Curology and our service providers may
+      use your Personal Information and your Sensitive Personal Information to:
+    </p>
+    <ul>
+      <li>Provide teledermatology and related services.</li>
+      <li>Provide, operate, analyze usage of and improve the Services.</li>
+      <li>Verify your identity as the holder of an Account.</li>
+      <li>
+        Administer your Account or process payments and provide you with related
+        customer service.
+      </li>
+      <li>
+        Communicate with you about the Services, and to deliver any
+        administrative notices or alerts and communications relevant to your use
+        of the Services.
+      </li>
+      <li>
+        Tailor the features, performance and support of the Services to you and
+        your preferences.
+      </li>
+      <li>
+        Troubleshoot problems with the Website and provide you with customer
+        support.
+      </li>
+      <li>
+        Market our services and those of third parties that we believe may be of
+        interest to you.
+      </li>
+      <li>
+        Allow you to participate in sweepstakes, contests, or other promotions.
+        Some of these promotions may have additional rules explaining how we
+        will use and disclose your Personal information.
+      </li>
+    </ul>
+    <h3>Disclosure of Personal Information to Third Parties</h3>
+    <p>
+      Your Personal Information and Sensitive Personal Information may be
+      disclosed:
+    </p>
+    <ul>
+      <li>
+        To licensed medical providers (including those who provide healthcare
+        services, drugs or medical devices), so that they may provide you with
+        the teledermatology and related products and services you request.
+      </li>
+      <li>
+        To our third-party vendors acting on our behalf and to entities with
+        whom we may be collaborating to deliver the Services.
+      </li>
+      <li>
+        To third parties to permit them to send you marketing communications.
+      </li>
+      <li>
+        By you, on message boards, chat, profile pages and blogs and other
+        services to which you are able to post information and materials. Please
+        note that any information you post or disclose through these services
+        will become public information.
+      </li>
+    </ul>
+    <p>
+      The Services may contain links to third-party sites and services whose
+      information, privacy and security practices may be different than ours.
+      Before using these third-party sites or providing them with your Personal
+      Information, you should carefully review and evaluate the privacy notices
+      for such sites, as Curology has no control over information that is
+      submitted to, or collected by, these third parties.
+    </p>
+    <p>
+      In certain cases, you may be directed to a third-party site to provide
+      information to complete a transaction in connection with the Website. In
+      such cases, any information you provide to such third-party sites directly
+      to such third party will be subject to the applicable third party’s
+      privacy policy and terms of service. For example, Stripe, Inc. (“Stripe”)
+      provides third-party payment processing services for Curology. All
+      payments made to Curology will be processed by Stripe. The privacy
+      policies of Stripe may differ from those of Curology. Any information you
+      submit to Stripe will be governed by its privacy statements. Accordingly,
+      Curology encourages you to carefully read Stripe’s privacy statements.
+    </p>
+    <p>
+      <em>
+        CUROLOGY DOES NOT CONTROL AND IS NOT RESPONSIBLE FOR, HOW THIRD PARTIES
+        HANDLE YOUR PERSONAL INFORMATION. PLEASE EXERCISE CAUTION AND CONSULT
+        THE PRIVACY POLICIES POSTED ON EACH THIRD-PARTY WEBSITE FOR FURTHER
+        INFORMATION. CUROLOGY AND ITS OFFICERS, DIRECTORS, EMPLOYEES,
+        CONSULTANTS, REPRESENTATIVES, AND AGENTS EXPRESSLY DISCLAIM ANY AND ALL
+        LIABILITY RELATING TO THE ACCURACY, QUALITY, AVAILABILITY, RELIABILITY,
+        OR SECURITY OF ANY THIRD-PARTY WEBSITES. CUROLOGY AND ITS OFFICERS,
+        DIRECTORS, EMPLOYEES, CONSULTANTS, REPRESENTATIVES, AND AGENTS SHALL NOT
+        BE LIABLE FOR ANY UNAUTHORIZED USE OR DISCLOSURE OF YOUR PERSONAL
+        INFORMATION BY ANY SUCH THIRD PARTY IF SUCH PERSONAL INFORMATION IS
+        PROVIDED TO SUCH THIRD PARTY IN COMPLIANCE WITH THIS PRIVACY POLICY.
+      </em>
+    </p>
+    <h3>Other Uses and Disclosures</h3>
+    <p>
+      We may also use and disclose your Personal Information as we believe to be
+      necessary or appropriate:
+    </p>
+    <ul>
+      <li>
+        To comply with law enforcement requests, for example, to respond to
+        subpoenas, court orders or legal processes.
+      </li>
+      <li>
+        In connection with any merger, financing, acquisition, bankruptcy,
+        dissolution, transaction or proceeding involving sale, transfer,
+        divestiture or disclosure of all or a portion of our business or assets
+        to another person or entity.
+      </li>
+      <li>
+        To protect the safety of Curology, its customers, or any other person in
+        an emergency.
+      </li>
+      <li>
+        To fulfill any other obligation of Curology as required by law. In the
+        event that we are legally compelled to disclose your Personal
+        Information to a third party.
+      </li>
+      <li>
+        To investigate, deter, prevent, defend against or take other action
+        regarding violations of Curology’s Terms of Service, illegal activities,
+        suspected fraud or situations involving potential threats to the legal
+        rights or physical safety of any person or the security of Curology’s
+        network or the Services.
+      </li>
+    </ul>
+    <h2>Collection and Use of Other Information</h2>
+    <p>
+      Curology may automatically collect information about your use of the
+      Services through your browser or device, IP address or through data
+      collection tools, such as web beacons and cookies (“Usage Data”). This may
+      include information about the date and time of your website session,
+      geographic location, and how you have navigated the website, browser and
+      device information and other information collected through our weblogs,
+      cookies, or in other ways. We use Usage Data to manage and secure our
+      websites, network systems, and other assets and to help us understand and
+      improve our Websites and Products design, functionality, and usability. We
+      also use Usage Data to monitor usage patterns, store information about
+      user preferences and to improve the Services.
+    </p>
+    <p>
+      We may use and disclose Usage Data for any purpose, except where
+      prohibited by applicable law. If we are required to treat Usage Data as
+      Personal Information under applicable law, then we may use and disclose it
+      for the purposes for which we use and disclose Personal Information as
+      detailed in this Privacy Policy.
+    </p>
+    <p>
+      In some instances, we may combine Usage Data with Personal Information. If
+      we do, we will treat the combined information as Personal Information as
+      long as it is combined.
+    </p>
+    <p>
+      <b>Through your browser or device</b>: Certain information is collected by
+      most browsers or automatically through your device, such as your Media
+      Access Control (MAC) address, computer type (Windows or Mac), screen
+      resolution, operating system name and version, device manufacturer and
+      model, language, and Internet browser type and version. We use this
+      information to ensure that the Website functions properly.
+    </p>
+    <p>
+      <b>IP Address</b>: Your IP Address is a number that is automatically
+      assigned to your computer by your Internet Service Provider. An IP Address
+      may be identified and logged automatically in our server log files
+      whenever a user accesses the Services, along with the time of the visit
+      and the pages visited. We use IP Addresses for purposes such as
+      calculating usage levels, diagnosing server problems, and administering
+      the Services. We may also derive your approximate location from your IP
+      Address.
+    </p>
+    <p>
+      <b>Web Beacons</b>: A “web beacon” is a piece of code that enables us to
+      monitor user activity and website traffic and, consistent with common
+      industry practice, we may use web beacons in commercial emails we send to
+      help us understand if emails are opened.
+    </p>
+    <p>
+      <b>Cookies</b>: A “cookie” is a randomly-generated unique numeric code
+      stored in the user’s web browser settings or computer’s hard drive. A
+      cookie typically contains the name of the domain (internet location) from
+      which the cookie originated, when it expires, as well as a randomly
+      generated unique numeric code.
+    </p>
+    <p>
+      <b>Anonymized or Aggregated Information</b>: Curology may aggregate
+      information or create anonymized information from your Personal
+      Information, which does not identify you (for purposes of this privacy
+      policy, we refer to this aggregated or anonymized data as (“Anonymous
+      Information”). Curology reserves the right to use or disclose Anonymous
+      Information without restriction, subject to applicable law.
+    </p>
+    <p>
+      <b>Our Advertising</b>: We use third-party advertising companies to serve
+      advertising that may be of interest to you when you access and use the
+      Services and other online services, based on information relating to your
+      access to and use of the Services and other online services, on any of
+      your devices, as well as information received from third parties. To do
+      so, these companies may place or recognize a unique cookie on your browser
+      (including through the use of pixel tags). They may also use these
+      technologies, along with information they collect about your online use,
+      to recognize you across the devices you use, such as a mobile phone and a
+      laptop. If you would like more information about this practice, and to
+      learn how to opt out of it in desktop and mobile browsers on the
+      particular device on which you are accessing this Privacy Policy, please
+      visit{' '}
+      <a
+        href="http://www.aboutads.info/consumers"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        http://www.aboutads.info/consumers
+      </a>
+      .
+    </p>
+    <h2>Protection of Personal Information</h2>
+    <p>
+      Curology seeks to employ reasonable physical, electronic, and
+      administrative security measures, designed to safeguard your Personal
+      Information within our organization.
+    </p>
+    <p>
+      However, please be aware that no method of data transmission over the
+      Internet or method of electronic storage can be guaranteed to be perfectly
+      secure. As a result, while Curology takes the measures stated above to
+      protect your Personal Information, it cannot ensure or guarantee the
+      security of any information you transmit to Curology or through the
+      Website.{' '}
+      <em>
+        ACCORDINGLY, CUROLOGY DOES NOT COVENANT, REPRESENT, OR WARRANT THAT THE
+        TRANSMISSION OR STORAGE OF YOUR PERSONAL INFORMATION ONLINE WILL BE
+        SECURE, AND YOU PROVIDE CUROLOGY WITH PERSONAL INFORMATION AND/OR
+        SENSITIVE PERSONAL INFORMATION, AT YOUR OWN RISK.
+      </em>
+    </p>
+    <p>
+      Your cooperation is imperative in safeguarding your Personal Information.
+      Choose your Account password carefully, as anyone with access to your
+      Account password will be able to assume your online identity and view your
+      medical information, change your Personal Information, and communicate
+      with your Curology health care providers. It is your responsibility to
+      prevent disclosure of your password to others, and to change your password
+      if you feel that its security has been compromised. You may change your
+      password from your Account profile page after logging into your Account.
+    </p>
+    <p>
+      Additionally, you will periodically receive correspondence from Curology
+      at the email address you register with your Account. While these emails
+      will never contain your photos or payment information, they will sometimes
+      include information relating to the details of your treatment (as
+      applicable). Accordingly, it is critical that you safeguard your
+      designated email address and restrict access thereto. The registration of
+      an email address with your Account indicates your consent for Curology to
+      transmit your Personal Information, including your Sensitive Personal
+      Information, to such address.
+    </p>
+    <h2>Opting Out Of Future Communications</h2>
+    <p>
+      You can stop receiving marketing emails from Curology by clicking the
+      unsubscribe link included at the bottom of a Curology marketing email. You
+      cannot opt out of certain emails we need to send you relating to normal
+      business operations (for example, notifying you of a message from your
+      medical provider). To opt out of all emails from Curology, you may email{' '}
+      <a href="mailto:support@curology.com">support@curology.com</a> and cancel
+      your Curology membership.
+    </p>
+    <h2>
+      Accessing, Correcting, Updating, and Deleting Your Personal Information
+    </h2>
+    <p>
+      You may access and update certain information in your Account, or
+      deactivate your Account from your Account profile page after logging into
+      your Account.
+    </p>
+    <p>
+      You may also, inspect and copy your Personal Information that you have
+      provided to us or amend your Personal Information if you believe your file
+      is incomplete, incorrect or obsolete.
+    </p>
+    <p>
+      Curology will make reasonable efforts to respond promptly to all such
+      requests. Curology may impose a fee for the costs associated with your
+      request, including the costs of labor, materials and/or shipping. In
+      certain circumstances, Curology may deny your request, for example if we
+      have legal obligations to maintain original copies of certain data and you
+      request it to be modified. If we do, we will inform you of why we have
+      refused a request.
+    </p>
+    <p>
+      You may at any time make a request for Curology to delete your Personal
+      Information. Curology will comply with all such requests as soon as
+      reasonably practicable, but only to the extent such requests are not in
+      conflict with any requirements to retain such information pursuant to
+      applicable law, contract or otherwise. When we delete your Personal
+      Information, it will be deleted from the active database, but may remain
+      in our archives.
+    </p>
+    <h2>Persons under the Age of 18</h2>
+    <p>
+      Persons under thirteen (13) years of age are not eligible to use the
+      Services. Further, Curology does not knowingly collect Personal
+      Information from anyone between the ages of thirteen (13) and eighteen
+      (18) without authorization from the parent or legal guardian of such
+      individual. A parent or guardian of a person under the age of eighteen
+      (18) may review and request deletion of such individual’s Personal
+      Information as well as prohibit our use thereof. If you are a parent or
+      guardian of an individual under the age of eighteen (18) and believe your
+      child has disclosed Personal Information to Curology without your consent
+      or authorization, please contact us at{' '}
+      <a href="mailto:support@curology.com">support@curology.com</a>.
+    </p>
+    <h2>Updates to This Privacy Policy</h2>
+    <p>
+      The “LAST UPDATED” legend at the top of this Privacy Policy indicates when
+      this Privacy Policy was last revised. Any changes will become effective
+      when we post the revised Privacy Policy on the Services. Your use of the
+      Services following these changes means that you accept the revised Privacy
+      Policy.
+    </p>
+    <h2>Social Media Plugins</h2>
+    <p>
+      When you use our Websites, Products, or Accounts online, Social Media
+      operators can place a cookie on your computer to recognize individuals who
+      have previously visited the Websites. If you are logged into a Social
+      Media account while using the Websites, Products, or Accounts online,
+      social plugins may allow that Social Media to receive information that you
+      have accessed and used the Websites, Products or Accounts. The social
+      plugins may also allow the Social Media operator to share information
+      about your activities in or through the Websites with other Social Media
+      users. For example, Facebook Social Plugins allows Facebook to show your
+      Likes and comments on our pages to your Facebook friends. Facebook Social
+      Plugins also allows you to see your friends’ Facebook activity through the
+      Services. Curology does not control Social Media plugins or the content
+      they create, collect, share, or process. For more information about Social
+      Media plugins, please refer to the privacy statements and other legal
+      notices of the Social Media platform.
+    </p>
+    <h2>Your California Privacy Rights</h2>
+    <p>
+      If you are a California resident under age 18 and are a registered user of
+      any of the Services, then you may request that we remove any information
+      you publicly posted on or in the Services. To request removal, please send
+      a request with a detailed description of the specific post to the support
+      contact information below. (You also may be able to log in to your account
+      and delete your own information as set forth above). Curology reserves the
+      right to request that you provide information that will enable us to
+      confirm that the post that you want removed was created and posted by you.
+    </p>
+    <p>
+      Curology will make a good faith effort to delete or remove your post from
+      public view as soon as reasonably practicable. Please note, however, that
+      your request that we delete your post does not ensure complete or
+      comprehensive removal of your post. Your post may remain on backup media,
+      cached or otherwise retained by Curology for administrative or legal
+      purposes or your post may remain publicly available if you or someone else
+      has forwarded or re-posted your post on another website or service prior
+      to its deletion. Curology may also be required by law to not remove (or
+      allow removal) of your post.
+    </p>
+    <p>
+      California Civil Code Section 1798.83 permits individual California
+      residents to request certain information regarding Curology’s disclosure
+      of personal information to third parties for their direct marketing
+      purposes. To make such a request, please write or send an email to:
+    </p>
+    <p>
+      <i>
+        Privacy Office
+        <br />
+        Curology, Inc
+        <br />
+        369 Hayes Street
+        <br />
+        San Francisco, CA 94102
+        <br />
+        privacy@curology.com
+        <br />
+      </i>
+    </p>
+    <p>
+      Be sure to include your name, address, and email address if you want to
+      receive a response by email. Otherwise, we will respond by postal mail
+      within the time required by applicable law.
+    </p>
+    <h2>Jurisdictional Issues</h2>
+    <p>
+      The Services are controlled and operated by us from the United States and
+      are not intended to subject us to the laws or jurisdiction of any state,
+      country or territory other than that of the United States.
+    </p>
+    <h2>Contact Us</h2>
+    <p>
+      If you have questions or concerns about this Privacy Policy, please
+      contact us at{' '}
+      <a href="mailto:privacy@curology.com">privacy@curology.com</a>.
+    </p>
+  </LegalContainer>
+);
+
+export default PrivacyPolicy;

--- a/src/shared-components/legalComponents/style.js
+++ b/src/shared-components/legalComponents/style.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import { style as TYPOGRAPHY_STYLE } from '../../typography';
-import { SPACER, FONTS } from '../../../constants';
+import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { SPACER, FONTS } from '../../constants';
 
 // eslint-disable-next-line import/prefer-default-export
 export const LegalContainer = styled.div`

--- a/src/shared-components/legalComponents/style.js
+++ b/src/shared-components/legalComponents/style.js
@@ -1,0 +1,85 @@
+import styled from '@emotion/styled';
+
+import { style as TYPOGRAPHY_STYLE } from '../../typography';
+import { SPACER, FONTS } from '../../../constants';
+
+// eslint-disable-next-line import/prefer-default-export
+export const LegalContainer = styled.div`
+  & * {
+    font-family: ${FONTS.baseFont};
+  }
+
+  & h1 {
+    ${TYPOGRAPHY_STYLE.display};
+    margin: 0;
+  }
+  
+  & h2 {
+    ${TYPOGRAPHY_STYLE.heading};
+    margin: ${SPACER.x2large} 0 0;
+  }
+  
+  & h3 {
+    ${TYPOGRAPHY_STYLE.title};
+    margin: ${SPACER.x2large} 0 0;
+  }
+  
+  & p {
+    ${TYPOGRAPHY_STYLE.body};
+    margin: ${SPACER.medium} 0 0;
+  }
+  
+  & a {
+    ${TYPOGRAPHY_STYLE.link};
+  }
+  
+  & time {
+    ${TYPOGRAPHY_STYLE.caption};
+    margin: ${SPACER.medium} 0 0;
+  }
+  
+  & em {
+    text-transform: uppercase;
+    font-size: 16px;
+    font-style: normal;
+    letter-spacing: .25px;
+  }
+  
+  & li {
+    ${TYPOGRAPHY_STYLE.body};
+    margin: ${SPACER.medium} 0 0;
+  }
+  
+  & ul {
+    list-style: disc;
+    padding-left: ${SPACER.large};
+    margin: ${SPACER.medium} 0 0 ${SPACER.medium};
+    
+    & > li {
+      text-indent: 0;
+    }
+  }
+  
+  & ol {
+    margin-top: ${SPACER.large};
+    margin-left: ${SPACER.large};
+    padding: 0;
+    counter-reset: item;
+  
+    > li {
+      padding: 0 0 0 ${SPACER.large};
+      text-indent: -${SPACER.large};
+      list-style-type: none;
+      counter-increment: item;
+    
+      &::before {
+        display: inline-block;
+        padding-right: ${SPACER.medium};
+        font-weight: bold;
+        text-align: right;
+        content: counter(item) ".";
+        width: ${SPACER.large};
+      }
+    }
+  }
+`;

--- a/src/shared-components/legalComponents/telehealthConsent/index.js
+++ b/src/shared-components/legalComponents/telehealthConsent/index.js
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import { LegalContainer } from '../style';
+
+const TelehealthConsent = () => (
+  <LegalContainer>
+    <h1>Consent to Treatment via Telehealth</h1>
+    <time dateTime="2019-01-09">Last Updated: January 9, 2019</time>
+    <ol>
+      <li>
+        I understand that Curology, Inc.’s affiliated healthcare providers
+        (“healthcare provider”) treat patients via telehealth, and I wish to be
+        treated via telehealth. I understand that my telehealth treatment may
+        involve all of the following (collectively “telehealth visit”):
+        <ul>
+          <li>
+            Electronic creation and transmission of medical records, photo
+            images, personal health information, or other data between me as the
+            patient and healthcare providers and among healthcare providers and
+            entities; and
+          </li>
+          <li>
+            Interactions between me and a healthcare provider via data
+            communications (including store and forward technology); and
+          </li>
+        </ul>
+      </li>
+      <li>
+        I understand there are potential risks to a telehealth visit, including
+        interruptions, unauthorized access which could disclose my health
+        information, and technical difficulties. I understand that my healthcare
+        provider or I can discontinue the treatment via telehealth visit if it
+        is felt that the situation warrants.
+      </li>
+      <li>
+        I understand that my health information as part of the telehealth visit
+        may be shared with other individuals or entities for technological and
+        billing purposes and any information collected by my healthcare provider
+        as part of this telehealth visit will be used for analyzing my health,
+        possible treatments, to conduct follow-up activities with me, including
+        to offer other Curology products and services to me, and will be used
+        further as stated in the Curology{' '}
+        <a href="/privacy" target="_blank" rel="noopener noreferrer">
+          Privacy Policy
+        </a>
+        .
+      </li>
+      <li>
+        I understand that my care at Curology is limited to the diagnosis and
+        treatment of acne and skin aging and related disorders and not for the
+        diagnosis or treatment of any other medical or dermatological
+        conditions, including skin cancer. I understand that the Website is not
+        a substitute for the in-person treatment or advice of my local
+        dermatologist, primary care physician, or any other qualified healthcare
+        professional. I understand that I should never delay seeking advice from
+        my local dermatologist, primary care physician, or any other health
+        professionals if advised to do so by my Curology healthcare provider, or
+        if I have any concerns.
+      </li>
+      <li>
+        I understand that Curology undertakes no obligation to review the
+        inactive ingredients and or the base ingredients in any product that is
+        recommended or sold to me, including, without limitation, to ascertain
+        that I am not allergic to such inactive or base ingredients. I further
+        understand that it is solely my responsibility to review those
+        ingredients, as listed on the Curology website.
+      </li>
+      <li>
+        I understand that if I have an emergency health issue of any nature, I
+        should call my local emergency medical number or take such other action
+        as I deem necessary.
+      </li>
+      <li>
+        I understand that I have the right to request that the Medical Record
+        established with Curology be sent to my primary healthcare provider. I
+        may request this on my{' '}
+        <a
+          href="/app/dashboard/request-medical-record"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          dashboard
+        </a>
+        .
+      </li>
+    </ol>
+    <p>By continuing, I represent:</p>
+    <ul>
+      <li>
+        That I have read or had this form read and/or had this form explained to
+        me.
+      </li>
+      <li>
+        That I fully understand its contents, including the risks and benefits
+        of the telehealth service provided through Curology’s affiliates.
+      </li>
+    </ul>
+  </LegalContainer>
+);
+
+export default TelehealthConsent;

--- a/src/shared-components/legalComponents/termsOfService/index.js
+++ b/src/shared-components/legalComponents/termsOfService/index.js
@@ -1,0 +1,814 @@
+import React from 'react';
+
+import { LegalContainer } from '../style';
+
+const TermsOfService = () => (
+  <LegalContainer>
+    <h1>Terms of Service</h1>
+    <time dateTime="2019-06-05">Last Updated: June 5, 2019</time>
+    <p>
+      Please read these Terms of Service (the “<u>Agreement</u>
+      ”) carefully. Your use of the Website (as defined below) constitutes your
+      consent to this Agreement.
+    </p>
+    <p>
+      This Agreement is between you and Curology, Inc. (“
+      <u>Company</u>” or “<u>we</u>” or “<u>us</u>
+      ”) concerning your use of (including any access to) the Curology site
+      currently located at{' '}
+      <a href="https://curology.com" target="_blank" rel="noopener noreferrer">
+        https://curology.com
+      </a>{' '}
+      (together with any materials and services available therein, and successor
+      site(s) thereto, the “<u>Website</u>
+      ”). This Agreement hereby incorporates by this reference any additional
+      terms and conditions posted by Company through the Website, or otherwise
+      made available to you by Company (“
+      <u>Additional Terms</u>
+      ”).
+    </p>
+    <p>
+      Please note that the Website may identify, or make available products or
+      services of, certain healthcare providers (“
+      <u>Provider Entities</u>
+      ”). Any Provider Entities are third parties, and any such products or
+      services (which may include healthcare services, drugs or medical devices)
+      are considered Third Party Materials, as defined below. Company itself is
+      not a healthcare provider, and is not responsible for any such Third Party
+      Materials.
+    </p>
+    <p>
+      <em>
+        By using the Website, you affirm that you are of legal age to enter into
+        this Agreement or, if you are not, that you have obtained parental or
+        guardian consent to enter into this Agreement. Notwithstanding the
+        foregoing, minors under thirteen (13) years old are not permitted to
+        access or use the Website or to enter into this Agreement, even if a
+        parent or legal guardian would be willing to provide consent.
+      </em>{' '}
+      A parent or legal guardian of an individual under the age of eighteen (18)
+      may prohibit such individual’s use of the Website. If you are the parent
+      or legal guardian of an individual under the age of eighteen (18) and
+      believe that such individual has used the Website without your consent or
+      authorization, please contact us at{' '}
+      <a href="mailto:support@curology.com">support@curology.com</a>.
+    </p>
+    <p>
+      <em>
+        This Agreement contains a mandatory arbitration provision that, as set
+        forth in Section 20 below, requires the use of arbitration on an
+        individual basis to resolve disputes, rather than jury trials or any
+        other court proceedings, or class actions of any kind.
+      </em>
+    </p>
+    <h2>1. Changes</h2>
+    <p>
+      We may change this Agreement from time to time by notifying you of such
+      changes by any reasonable means, including by posting a revised Agreement
+      through the Website. Any such changes will not apply to any dispute
+      between you and us arising prior to the date on which we posted the
+      revised Agreement incorporating such changes or otherwise notified you of
+      such changes.
+    </p>
+    <p>
+      Your use of the Website following any changes to this Agreement will
+      constitute your acceptance of such changes. The “<i>Last Updated</i>”
+      legend above indicates when this Agreement was last changed. We may, at
+      any time and without liability, modify or discontinue all or part of the
+      Website (including access to the Website via any third-party links);
+      charge, modify or waive any fees required to use the Website; or offer
+      opportunities to some or all Website users.
+    </p>
+    <h2>2. Information Submitted Through the Website</h2>
+    <p>
+      Your submission of information through the Website is governed by
+      Company’s Privacy and Security Policy, located at{' '}
+      <a
+        href="https://curology.com/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        https://curology.com/privacy
+      </a>{' '}
+      (the “<u>Privacy Policy</u>
+      ”). You represent and warrant that any information you provide in
+      connection with the Website is and will remain accurate and complete and
+      that you will maintain and update such information as needed.
+    </p>
+    <h2>3. Jurisdictional Issues</h2>
+    <p>
+      The Website is controlled or operated (or both) from the United States and
+      is not intended to subject Company to any non-U.S. jurisdiction or law.
+      The Website may not be appropriate or available for use in some non-U.S.
+      jurisdictions. Any use of the Website is at your own risk, and you must
+      comply with all applicable laws, rules and regulations in doing so. We may
+      limit the Website’s availability at any time, in whole or in part, to any
+      person, geographic area or jurisdiction that we choose.
+    </p>
+    <h2>4. Important Acknowledgements</h2>
+    <ul>
+      <li>
+        You understand that you will periodically receive correspondence from
+        Curology at the email address you register with your Account. While these
+        emails will never contain your photos or payment information, they will
+        sometimes include information relating to the details of your treatment
+        (as applicable). Accordingly, it is critical that you safeguard your
+        designated email address and restrict access thereto. The registration
+        of an email address with your Account indicates your consent for Curology
+        to transmit your Personal Information, including your Sensitive Personal
+        Information, to such address. For more information on Personal Information
+        and Sensitive Personal Information, review our{' '}
+        <a
+          href="https://curology.com/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Privacy Policy
+        </a>
+        .
+      </li>
+      <li>
+        You understand that the teledermatology services and any customized
+        prescription products made available through the Website are provided by
+        U.S. licensed medical providers rather than by Company and that Company
+        is not itself a healthcare provider.
+      </li>
+      <li>
+        You understand that the Website and Products (as “Products” is defined
+        in Section 6, below) facilitate dermatology consultations limited to the
+        diagnosis and treatment of acne and skin aging (and related conditions),
+        and not for any other medical or dermatological conditions, including
+        skin cancer.
+      </li>
+      <li>
+        You understand that the Website is not a substitute for the in-person
+        treatment or advice of your local dermatologist, primary care physician
+        or any other qualified healthcare professional.
+      </li>
+      <li>
+        You understand that you should never delay seeking advice from your
+        dermatologist, primary care physician or any other health professionals
+        due to any diagnosis, advice or other information provided (or the
+        omission of any such information) by Company, the Website or the
+        Products, or a healthcare provider through Company, the Website or the
+        Products.
+      </li>
+      <li>
+        <b>
+          You understand that the Website is not to be used in connection with
+          medical emergencies. If you are experiencing a medical crisis, please
+          call 9-1-1 or contact your local emergency assistance services
+          immediately. If you are not feeling well, please contact your primary
+          care physician.
+        </b>
+      </li>
+      <li>
+        You understand that Curology undertakes no obligation to review the
+        inactive ingredients and/or the base ingredients in any product that is
+        recommended or sold to you through the Website, including, without
+        limitation, to ascertain that you are not allergic to such inactive or
+        base ingredients. You further understand that it is solely your
+        responsibility to review those ingredients, as listed on the Website.
+      </li>
+    </ul>
+    <h2>5. Rules of Conduct</h2>
+    <p>In connection with the Website, you must not:</p>
+    <ul>
+      <li>
+        Contact or seek to contact any healthcare professional associated with
+        Company outside of the Website. This is in order to protect both
+        patients and healthcare professionals and to ensure that diagnosis and
+        treatment is delivered in a reliable, continuous and controlled
+        environment.
+      </li>
+      <li>
+        Post, transmit or otherwise make available through or in connection with
+        the Website any materials that are or may be: (a) threatening,
+        harassing, degrading, hateful or intimidating or otherwise fail to
+        respect the rights and dignity of others; (b) defamatory, libelous,
+        fraudulent or otherwise tortious; (c) obscene, indecent, pornographic or
+        otherwise objectionable; or (d) protected by copyright, trademark, trade
+        secret, right of publicity or privacy or any other proprietary right,
+        without the express prior written consent of the applicable owner.
+      </li>
+      <li>
+        Post, transmit or otherwise make available through or in connection with
+        the Website any virus, worm, Trojan horse, Easter egg, time bomb,
+        spyware or other computer code, file or program that is or is
+        potentially harmful or invasive or intended to damage or hijack the
+        operation of, or to monitor the use of, any hardware, software or
+        equipment (each, a “Virus”).
+      </li>
+      <li>
+        Allow, enable, or otherwise support the transmission of unsolicited or
+        unauthorized advertising, junk or bulk email (SPAM), chain letters,
+        letters relating to a pyramid scheme, or any other unsolicited
+        commercial or non-commercial communication.
+      </li>
+      <li>
+        Use the Website for any commercial purpose or for any purpose that is
+        fraudulent or otherwise unlawful.
+      </li>
+      <li>
+        Create a false identity for the purpose of misleading others,
+        impersonate any person or entity, or otherwise misrepresent your
+        affiliation with a person or entity.
+      </li>
+      <li>Harvest or collect information about users of the Website.</li>
+      <li>
+        Interfere with or disrupt the operation of the Website or the servers or
+        networks used to make the Website available, including by hacking or
+        defacing any portion of the Website; or violate any requirement,
+        procedure or policy of such servers or networks.
+      </li>
+      <li>Restrict or inhibit any other person from using the Website.</li>
+      <li>
+        Infringe the patent, trademark, trade secret, copyright or other
+        intellectual property or other rights of another person or entity.
+      </li>
+      <li>
+        Reproduce, modify, adapt, translate, create derivative works of, sell,
+        rent, lease, loan, timeshare, distribute or otherwise exploit any
+        portion of (or any use of) the Website except as expressly authorized
+        herein or otherwise use the Website for the benefit of a third party or
+        to operate a service bureau, without Company’s express prior written
+        consent.
+      </li>
+      <li>
+        Reverse engineer, decompile or disassemble any portion of the Website,
+        except where such restriction is expressly prohibited by applicable law.
+      </li>
+      <li>
+        Remove any copyright, trademark or other proprietary rights notice from
+        the Website.
+      </li>
+      <li>
+        Frame or mirror any portion of the Website, or otherwise incorporate any
+        portion of the Website into any product or service, without Company’s
+        express prior written consent.
+      </li>
+      <li>Systematically download and store Website content.</li>
+      <li>
+        Attempt to disable, bypass, modify, defeat or otherwise circumvent any
+        security related tools incorporated into or used in connection with the
+        Website.
+      </li>
+      <li>
+        Use any robot, spider, site search/retrieval application or other manual
+        or automatic device to retrieve, index, “scrape,” “data mine” or
+        otherwise gather Website content, or reproduce or circumvent the
+        navigational structure or presentation of the Website, without Company’s
+        express prior written consent.
+      </li>
+      <li>
+        “Frame” or “mirror” any Curology content which forms part of the
+        Website, place pop-up windows over its pages, or otherwise affect the
+        display of its pages.
+      </li>
+    </ul>
+    <p>
+      In connection with the Website, you shall notify Company immediately if
+      you become aware of any inaccuracies, errors, omissions or inconsistencies
+      in the information or content provided through the Website and to comply
+      with any corrective action taken by Company.
+    </p>
+    <p>
+      You are responsible for obtaining, maintaining and paying for all hardware
+      and all telecommunications and other services needed to use the Website.
+    </p>
+    <h2>6. Products</h2>
+    <p>
+      The Website may make available listings, descriptions and images of goods
+      or services or related coupons, discounts or trials of goods or services
+      (collectively, “<u>Products</u>
+      ”), as well as references and links to Products. The availability of any
+      Product (including the validity of any coupon or discount) are subject to
+      change at any time without notice. Certain weights, measures and similar
+      descriptions are approximate and are for convenience only. It is your
+      responsibility to ascertain and obey all applicable local, state, federal
+      and foreign laws (including minimum age requirements) regarding the
+      purchase, possession and use of any Product.
+    </p>
+    <h2>7. Transactions</h2>
+    <p>
+      We may make available the ability to (i) communicate with a healthcare
+      provider and (ii) purchase or otherwise obtain certain Products through
+      the Website, including trials of goods or services (both (i) and (ii)
+      referred to as a “<u>Transaction</u>
+      ”). If you wish to make a Transaction, you may be asked to supply certain
+      relevant information, such as your credit card number and its expiration
+      date, your billing address and your shipping information. You represent
+      and warrant that you have the right to use any credit card or other
+      payment information that you submit in connection with a Transaction. By
+      submitting such information, you hereby authorize Company to charge you
+      and grant to us the right to provide such information to third parties for
+      purposes of facilitating Transactions, including through Stripe, Inc. (“
+      <u>Stripe</u>
+      ”), Company’s third-party payment processing service. Verification of
+      information may be required prior to the acknowledgment or completion of
+      any Transaction. If your payment method fails or fees associated with your
+      Account are past due, we may collect fees owed using other collection
+      mechanisms, include charging other payment methods on file (including with
+      Stripe) and/or retaining collection agencies and legal counsel. By making
+      a Transaction, you represent that the applicable Products will be used
+      only in a lawful manner. We reserve the right to change the types of
+      Transactions for which we charge, and we reserve the right to charge for
+      consultations with your healthcare provider. Trials and subscriptions of
+      Products or services are subject to the terms and conditions applicable to
+      such trials and subscriptions available on the Website.
+    </p>
+    <p>
+      Company reserves the right, including without prior notice, to limit the
+      available quantity of or discontinue making available any Product; to
+      impose conditions on the honoring of any coupon, discount, trial or
+      similar promotion; to bar any user from making any Transaction; and to
+      refuse to provide any user with any Product.{' '}
+      <a
+        href="https://support.curology.com/article/101-return-policy"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Refunds and exchanges will be subject to Company’s applicable refund and
+        exchange policies
+      </a>
+      . You agree to pay all charges incurred by you or on your behalf through
+      the Website, at the prices in effect when such charges are incurred,
+      including all shipping and handling charges. In addition, you are
+      responsible for any taxes applicable to your Transactions. While it is our
+      practice to confirm orders by e-mail, the receipt of an e-mail order
+      confirmation does not constitute our acceptance of an order or our
+      confirmation of an offer to sell a Product or service.
+    </p>
+    <p>
+      Products will be shipped to an address designated by you, if applicable,
+      so long as such address is complete and complies with the shipping
+      restrictions contained on the Website. All Transactions are made pursuant
+      to a shipment contract, and, as a result, risk of loss and title for
+      Products pass to you upon delivery of the Products to the carrier. You are
+      responsible for filing any claims with carriers for damaged and/or lost
+      shipments.
+    </p>
+    <h2>8. Registration; User Names and Passwords</h2>
+    <p>
+      You may need to register to use all or part of the Website. We may reject,
+      or require that you change, any user name, password or other information
+      that you provide to us in registering. Your user name and password are for
+      your personal use only and should be kept confidential; you, and not
+      Company, are responsible for any use or misuse of your user name or
+      password, and you must promptly notify us of any confidentiality breach or
+      unauthorized use of your user name, password or Website account. You may
+      not use the Website account of any other Curology user at any time. If you
+      are under the age of 18, your user name and password should also be shared
+      with your parent or legal guardian for the purposes of monitoring your
+      medical care.
+    </p>
+    <h2>9. Profiles and Forums</h2>
+    <p>
+      Website visitors may make available certain materials (each, a “
+      <u>Submission</u>
+      ”) through or in connection with the Website, including on profile pages,
+      on social media or on the Website’s interactive services, such as message
+      boards and other forums, and chatting, commenting and other messaging
+      functionality. “Submissions” do not include your sensitive health
+      information. Company has no control over and is not responsible for any
+      use or misuse (including any distribution) by any third party of
+      Submissions.{' '}
+      <em>
+        If you choose to make any of your personally identifiable or other
+        information publicly available through the Website, you do so at your
+        own risk.
+      </em>
+    </p>
+    <h2>10. License</h2>
+    <p>
+      For purposes of clarity, you retain ownership of your Submissions. For
+      each Submission, you hereby grant to us a worldwide, royalty-free, fully
+      paid-up, non-exclusive, perpetual, irrevocable, transferable and fully
+      sublicensable (through multiple tiers) license, without additional
+      consideration to you or any third party, to reproduce, distribute, perform
+      and display (publicly or otherwise), create derivative works of, adapt,
+      modify and otherwise use, analyze and exploit such Submission, in any
+      format or media now known or hereafter developed, and for any purpose
+      (including promotional purposes, such as testimonials).
+    </p>
+    <p>
+      In addition, if you provide to us any ideas, proposals, suggestions or
+      other materials (“
+      <u>Feedback</u>
+      ”), whether related to the Website or otherwise, such Feedback will be
+      deemed a Submission, and you hereby acknowledge and agree that such
+      Feedback is not confidential and that your provision of such Feedback is
+      gratuitous, unsolicited and without restriction, and does not place
+      Company under any fiduciary or other obligation.
+    </p>
+    <p>
+      You represent and warrant that you have all rights necessary to grant the
+      licenses granted in this section, and that your Submissions, and your
+      provision thereof through and in connection with the Website, are complete
+      and accurate, and are not fraudulent, tortious or otherwise in violation
+      of any applicable law or any right of any third party. You further
+      irrevocably waive any “moral rights” or other rights with respect to
+      attribution of authorship or integrity of materials regarding each
+      Submission that you may have under any applicable law under any legal
+      theory.
+    </p>
+    <h2>11. Monitoring</h2>
+    <p>
+      We may and expressly reserve the right (but have no obligation) to
+      monitor, scan, intercept, review, analyze, store, evaluate, alter or
+      remove Submissions or any messages, information, content or other
+      materials sent to you, or received by you, in connection with the Website,
+      at any time, including while it is in transit, and before and after it is
+      stored or made available through the Website, and to monitor, review,
+      analyze or evaluate your access to or use of the Website, in each case by
+      manual, automated or other means, and in each case for any purpose,
+      including marketing and advertising and such purposes as may be described
+      in the Privacy Policy. We may disclose information regarding your access
+      to and use of the Website, and the circumstances surrounding such access
+      and use, to anyone for any reason or purpose.
+    </p>
+    <h2>12. Your Limited Rights</h2>
+    <p>
+      Subject to your compliance with this Agreement, and solely for so long as
+      you are permitted by Company to use the Website, you may view one (1) copy
+      of any portion of the Website to which we provide you access under this
+      Agreement, on any single device, solely for your personal, non-commercial
+      use.
+    </p>
+    <h2>13. Company’s Proprietary Rights</h2>
+    <p>
+      We and our suppliers own the Website, including the software, code,
+      proprietary methods, systems, content and any other intellectual property
+      or proprietary rights used to operate the Website (the “<b>Website IP</b>
+      ”), which is protected by proprietary rights and laws. The Website IP also
+      includes our trade names, trademarks and service marks, which include
+      CUROLOGY, and any associated logos. All Website IP on the Website not
+      owned by us are the property of their respective owners. You may not use
+      Website IP in connection with any product or service that is not ours, or
+      in any manner that is likely to cause confusion. Except for the limited
+      license set forth in Section 12, nothing contained on the Website should
+      be construed as granting any right to use any Website IP without the
+      express prior written consent of the owner.
+    </p>
+    <h2>14. Third Party Materials; Links</h2>
+    <p>
+      Certain Website functionality may make available access to information,
+      products, services and other materials made available by third parties,
+      including Submissions (“
+      <u>Third Party Materials</u>
+      ”), or allow for the routing or transmission of such Third Party
+      Materials, including via links. By using such functionality, you are
+      directing us to access, route and transmit to you the applicable Third
+      Party Materials.
+    </p>
+    <p>
+      We neither control nor endorse, nor are we responsible for, any Third
+      Party Materials, including the accuracy, validity, timeliness,
+      completeness, reliability, integrity, quality, legality, usefulness or
+      safety of Third Party Materials, or any intellectual property rights
+      therein. Certain Third Party Materials may, among other things, be
+      inaccurate, misleading or deceptive. Nothing in this Agreement shall be
+      deemed to be a representation or warranty by Company with respect to any
+      Third Party Materials. We have no obligation to monitor Third Party
+      Materials, and we may block or disable access to any Third Party Materials
+      (in whole or part) through the Website at any time. In addition, the
+      availability of any Third Party Materials through the Website does not
+      imply our endorsement of, or our affiliation with, any provider of such
+      Third Party Materials, nor does such availability create any legal
+      relationship between you and any such provider.
+    </p>
+    <p>
+      <em>
+        Your use of Third Party Materials is at your own risk and is subject to
+        any additional terms, conditions and policies applicable to such Third
+        Party Materials (such as terms of service or privacy policies of the
+        providers of such Third Party Materials).
+      </em>
+    </p>
+    <h2>15. Promotions</h2>
+    <p>
+      Any sweepstakes, contests, raffles, surveys, games or similar promotions
+      (collectively, “<u>Promotions</u>
+      ”) made available through the Website may be governed by rules that are
+      separate from this Agreement. If you participate in any Promotions, please
+      review the applicable rules as well as our Privacy Policy. If the rules
+      for a Promotion conflict with this Agreement, the Promotion rules will
+      govern.
+    </p>
+    <h2>16. Disclaimer of Warranties</h2>
+    <p>
+      <em>
+        To the fullest extent permitted under applicable law: (a) the Website
+        and any Products and Third Party Materials are made available to you on
+        an “As Is,” “Where Is” and “Where Available” basis, without any
+        warranties of any kind, whether express, implied or statutory; and (b)
+        Company disclaims all warranties with respect to the Website and any
+        Products and Third Party Materials, including the warranties of
+        merchantability, fitness for a particular purpose, non-infringement and
+        title.
+      </em>
+    </p>
+    <p>
+      <em>
+        You understand and agree that any information, products or services
+        obtained through the use of the Website is obtained at your own
+        discretion and risk, and that you will be solely responsible for any
+        damage or loss that results from the use thereof. no advice or
+        information, whether oral or written, obtained by you from Company or
+        the Website will create any warranty not expressly made herein.
+      </em>
+    </p>
+    <p>
+      <em>
+        All disclaimers of any kind (including in this section and elsewhere in
+        this Agreement) are made for the benefit of both Company and any
+        Provider Entities, and their affiliates and respective shareholders,
+        directors, officers, employees, affiliates, agents, representatives,
+        licensors, suppliers and service providers (collectively, the “
+        <u>Affiliated Entities</u>
+        ”), and their respective successors and assigns.
+      </em>
+    </p>
+    <p>
+      While we try to maintain the timeliness, integrity and security of the
+      Website, we do not guarantee that the Website is or will remain updated,
+      complete, correct or secure, or that access to the Website will be
+      uninterrupted. The Website may include inaccuracies, errors and materials
+      that violate or conflict with this Agreement. Additionally, third parties
+      may make unauthorized alterations to the Website. If you become aware of
+      any such alteration, contact us at{' '}
+      <a href="mailto:support@curology.com">support@curology.com</a> with a
+      description of such alteration and its location on the Website.
+    </p>
+    <h2>17. Limitation of Liability</h2>
+    <p>
+      <em>
+        To the fullest extent permitted under applicable law: (a) Company will
+        not be liable for any indirect, incidental, consequential, special,
+        exemplary or punitive damages of any kind, under any contract, tort
+        (including negligence), strict liability or other theory, including
+        damages for loss of profits, use or data, loss of other intangibles,
+        loss of security of Submissions (including unauthorized interception by
+        third parties of any Submissions), even if advised in advance of the
+        possibility of such damages or losses; (b) without limiting the
+        foregoing, Company will not be liable for damages of any kind resulting
+        from your use of or inability to use the Website or from any Products or
+        Third Party Materials, including from any Virus that may be transmitted
+        in connection therewith; (c) your sole and exclusive remedy for
+        dissatisfaction with the Website or any Products or Third Party
+        Materials is to stop using the Website; and (d) the maximum aggregate
+        liability of Company for all damages, losses and causes of action,
+        whether in contract, tort (including negligence) or otherwise, shall be
+        the greater of (1) the total amount, if any, paid by you to Company to
+        use the Website and (2) one hundred U.S. dollars ($100). If you are
+        dissatisfied with any portion of the Website, the products, or this
+        Agreement, your sole and exclusive remedy is to discontinue use of the
+        Website and/or products. All limitations of liability of any kind
+        (including in this section and elsewhere in this Agreement) are made for
+        the benefit of both Company and the Affiliated Entities, and their
+        respective successors and assigns.
+      </em>
+    </p>
+    <p>
+      Applicable law in states other than New Jersey (which is addressed in
+      Section 24, below) may not allow for limitations on certain implied
+      warranties, or exclusions or limitations of certain damages; solely to the
+      extent that such law applies to you, some or all of the above disclaimers,
+      exclusions or limitations of liability may not apply to you, and you may
+      have certain additional rights.
+    </p>
+    <h2>18. Indemnity and Release</h2>
+    <p>
+      To the fullest extent permitted under applicable law, you agree to defend,
+      indemnify and hold harmless Company and the Affiliated Entities, and their
+      respective successors and assigns, from and against all claims,
+      liabilities, damages, judgments, awards, losses, costs, expenses and fees
+      (including attorneys’ fees) arising out of or relating to (a) your use of,
+      or activities in connection with, the Website (including all Submissions);
+      and (b) any violation or alleged violation of this Agreement by you.
+    </p>
+    <h2>19. Termination</h2>
+    <p>
+      This Agreement is effective until terminated. You may deactivate your
+      Account at any time, for any reason, by sending an email to{' '}
+      <a href="mailto:support@curology.com">support@curology.com</a>. Company
+      may terminate or suspend your use of the Website at any time and without
+      prior notice, for any or no reason, including if Company believes that you
+      have violated or acted inconsistently with the letter or spirit of this
+      Agreement or if any amounts due by you to Company are past due. Upon any
+      such termination or suspension, your right to use the Website will
+      immediately cease, and Company may, without liability to you or any third
+      party, immediately deactivate or delete your user name, password and
+      account, and all associated materials, without any obligation to provide
+      any further access to such materials. Your medical records will be
+      retained by Company for a period of five (5) years, unless a longer period
+      is required by state or federal law, after which they may be destroyed. If
+      you are younger than twenty three (23) years old on the date the records
+      may potentially be destroyed, your records will be kept until you reach
+      the age of 23, or longer if required by state or federal law. Sections
+      2–6, 8–11 and 13–25 shall survive any expiration or termination of this
+      Agreement.] Any termination or discontinuance of the Website pursuant to
+      the provisions set forth in this Section 19 shall be subject to compliance
+      with any notice or waiting period provided by applicable law.
+    </p>
+    <h2>20. Governing Law; Arbitration</h2>
+    <p>
+      The terms of this Agreement are governed by the laws of the United States
+      (including federal arbitration law) and the State of California, U.S.A.,
+      without regard to its principles of conflicts of law, and regardless of
+      your location.{' '}
+      <em>
+        Except for disputes that qualify for small claims court, all disputes
+        arising out of or related to this Agreement or any aspect of the
+        relationship between you and Company, whether based in contract, tort,
+        statute, fraud, misrepresentation or any other legal theory, will be
+        resolved through final and binding arbitration before a neutral
+        arbitrator instead of in a court by a judge or jury and you agree that
+        Company and you are each waiving the right to trial by a jury. Except as
+        provided below regarding the class action waiver, such disputes include,
+        without limitation, disputes arising out of or relating to
+        interpretation or application of this arbitration provision, including
+        the enforceability, revocability or validity of the arbitration
+        provision or any portion of the arbitration provision. All such matters
+        shall be decided by an arbitrator and not by a court or judge.
+      </em>
+    </p>
+    <p>
+      <em>
+        You agree that any arbitration under this Agreement will take place on
+        an individual basis; class arbitrations and class actions are not
+        permitted and you are agreeing to give up the ability to participate in
+        a class action.
+      </em>
+    </p>
+    <p>
+      The arbitration will be administered by the American Arbitration
+      Association under its Consumer Arbitration Rules, as amended by this
+      Agreement. The Consumer Arbitration Rules are available online at{' '}
+      <a
+        href="https://www.adr.org/aaa/ShowProperty?nodeId=/UCM/ADRSTAGE2021425&revision=latestreleased"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        https://www.adr.org/aaa/ShowProperty?nodeId=/UCM/ADRSTAGE2021425&revision=latestreleased
+      </a>
+      . The arbitrator will conduct hearings, if any, by teleconference or
+      videoconference, rather than by personal appearances, unless the
+      arbitrator determines upon request by you or by us that an in-person
+      hearing is appropriate. Any in-person appearances will be held at a
+      location which is reasonably convenient to both parties with due
+      consideration of their ability to travel and other pertinent
+      circumstances. If the parties are unable to agree on a location, such
+      determination should be made by the AAA or by the arbitrator. The
+      arbitrator’s decision will follow the terms of this Agreement and will be
+      final and binding. The arbitrator will have authority to award temporary,
+      interim or permanent injunctive relief or relief providing for specific
+      performance of this Agreement, but only to the extent necessary to provide
+      relief warranted by the individual claim before the arbitrator. The award
+      rendered by the arbitrator may be confirmed and enforced in any court
+      having jurisdiction thereof. Notwithstanding any of the foregoing, nothing
+      in this Agreement will preclude you from bringing issues to the attention
+      of federal, state or local agencies and, if the law allows, they can seek
+      relief against us for you.
+    </p>
+    <h2>21. Filtering</h2>
+    <p>
+      We hereby notify you that parental control protections (such as computer
+      hardware, software or filtering services) are commercially available that
+      may assist you in limiting access to material that is harmful to minors.
+      Information identifying current providers of such protections is available
+      from{' '}
+      <a
+        href="https://en.wikipedia.org/wiki/Comparison_of_content-control_software_and_providers"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        https://en.wikipedia.org/wiki/Comparison_of_content-control_software_and_providers
+      </a>
+      . Please note that Company does not endorse any of the products or
+      services listed on such site.
+    </p>
+    <h2>22. Information or Complaints</h2>
+    <p>
+      If you have a question or complaint regarding the Website, please send an
+      e-mail to <a href="mailto:support@curology.com">support@curology.com</a>.
+      You may also contact us by writing to 5717 Pacific Center Blvd, Suite 200,
+      San Diego, CA 92121. Please note that e-mail communications will not
+      necessarily be secure; accordingly you should not include credit card
+      information or other sensitive information in your e-mail correspondence
+      with us. California residents may reach the Complaint Assistance Unit of
+      the Division of Consumer Services of the California Department of Consumer
+      Affairs by mail at 1625 North Market Blvd., Sacramento, CA 95834, or by
+      telephone at (916) 445-1254 or (800) 952-5210.
+    </p>
+    <h2>23. Copyright Infringement Claims</h2>
+    <p>
+      The Digital Millennium Copyright Act of 1998 (the “DMCA”) provides
+      recourse for copyright owners who believe that material appearing on the
+      Internet infringes their rights under U.S. copyright law. If you believe
+      in good faith that materials available on the Website infringe your
+      copyright, you (or your agent) may send to Company a written notice by
+      mail, e-mail or fax, requesting that Company remove such material or block
+      access to it. If you believe in good faith that someone has wrongly filed
+      a notice of copyright infringement against you, the DMCA permits you to
+      send to Company a counter-notice. Notices and counter-notices must meet
+      the then-current statutory requirements imposed by the DMCA. See{' '}
+      <a
+        href="http://www.copyright.gov/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        http://www.copyright.gov/
+      </a>{' '}
+      for details. Notices and counter-notices must be sent in writing to
+      Company’s DMCA agent as follows: By mail to VP Legal, Curology, Inc., 369
+      Hayes Street, San Francisco, CA 94102; by e-mail to{' '}
+      <a href="mailto:Shawn@curology.com">Shawn@curology.com</a>. Company’s DMCA
+      agent’s phone number is 650-245-2461.
+    </p>
+    <p>
+      We suggest that you consult your legal advisor before filing a DMCA notice
+      or counter-notice.
+    </p>
+    <h2>24. Important Note to New Jersey Consumers</h2>
+    <p>
+      If you are a consumer residing in New Jersey, the following provisions of
+      this Agreement do not apply to you (and do not limit any rights that you
+      may have) to the extent they are unenforceable under New Jersey law: (a)
+      the disclaimer of liability for any indirect, incidental, consequential,
+      special, exemplary or punitive damages of any kind (for example, to the
+      extent unenforceable under the New Jersey Punitive Damages Act, New Jersey
+      Products Liability Act, New Jersey Uniform Commercial Code and New Jersey
+      Consumer Fraud Act); (b) the limitation on liability for loss of profits
+      or loss or use of data (for example, to the extent unenforceable under the
+      New Jersey Identity Theft Protection Act and New Jersey Consumer Fraud
+      Act); (c) application of the limitations of liability to the recovery of
+      damages that arise under any contract, tort (including negligence), strict
+      liability or any other theory (for example, to the extent such damages are
+      recoverable by a consumer under New Jersey law, including the New Jersey
+      Products Liability Act); (d) the requirement that you indemnity Company
+      (for example, to the extent the scope of such indemnity is prohibited
+      under New Jersey law); and (e) the California governing law provision (for
+      example, to the extent that your rights as a consumer residing in New
+      Jersey are required to be governed by New Jersey law).
+    </p>
+    <h2>25. Export Controls</h2>
+    <p>
+      You are responsible for complying with United States export controls and
+      for any violation of such controls, including any United States embargoes
+      or other federal rules and regulations restricting exports. You represent,
+      warrant and covenant that you are not (a) located in, or a resident or a
+      national of, any country subject to a U.S. government embargo or other
+      restriction, or that has been designated by the U.S. government as a
+      “terrorist supporting” country; or (b) on any of the U.S. government lists
+      of restricted end users.
+    </p>
+    <h2>26. Miscellaneous</h2>
+    <p>
+      This Agreement does not, and shall not be construed to, create any
+      partnership, joint venture, employer-employee, agency or
+      franchisor-franchisee relationship between you and Company. If any
+      provision of this Agreement is found to be unlawful, void or for any
+      reason unenforceable, that provision will be deemed severable from this
+      Agreement and will not affect the validity and enforceability of any
+      remaining provision. You may not assign, transfer or sublicense any or all
+      of your rights or obligations under this Agreement without our express
+      prior written consent. We may assign, transfer or sublicense any or all of
+      our rights or obligations under this Agreement without restriction,
+      including, without limitation, those rights or obligations relating to
+      your Website account and any information that you provide or that has been
+      provided on your behalf to Company or that has been collected by Company
+      in connection with Company’s business operations or through the Website.
+      No waiver by either party of any breach or default under this Agreement
+      will be deemed to be a waiver of any preceding or subsequent breach or
+      default. Any heading, caption or section title contained herein is for
+      convenience only, and in no way defines or explains any section or
+      provision. All terms defined in the singular shall have the same meanings
+      when used in the plural, where appropriate and unless otherwise specified.
+      Any use of the term “including” or variations thereof in this Agreement
+      shall be construed as if followed by the phrase “without limitation.” To
+      the extent there is a conflict between the provisions in this Agreement
+      and any Additional Terms incorporated herein by reference, the latter
+      shall have precedence. This Agreement, including any terms and conditions
+      incorporated herein, is the entire agreement between you and Company
+      relating to the subject matter hereof, and supersedes any and all prior or
+      contemporaneous written or oral agreements or understandings between you
+      and Company relating to such subject matter. Notices to you (including
+      notices of changes to this Agreement) may be made via posting to the
+      Website or by e-mail (including in each case via links), or by regular
+      mail. Without limitation, a printed version of this Agreement and of any
+      notice given in electronic form shall be admissible in judicial or
+      administrative proceedings based upon or relating to this Agreement to the
+      same extent and subject to the same conditions as other business documents
+      and records originally generated and maintained in printed form. Company
+      will not be responsible for any failure to fulfill any obligation due to
+      any cause beyond its control.
+    </p>
+    <p>
+      Website © 2014–2019 Curology, Inc. unless otherwise noted. All rights
+      reserved.
+    </p>
+  </LegalContainer>
+);
+
+export default TermsOfService;


### PR DESCRIPTION
Trello: https://trello.com/c/VgBHk5v8

We use the legal pages in both Gatsby (as the static legal pages) and in the main app (as part of the legal modal component). This was causing issues where there was not a single source of truth for the content. Case in point, when adding these to radiance and comparing the dates updated on the two repos, there was an instance where the information on the main app was updated and the gatsby one was not.

From here, we can use the following components in either repo:
```
<TermsOfService />
<PrivacyPolicy />
<Disclaimer />
<TelehealthConsent />
<ParentGuardianTelehealthConsent />
<LegalContainer />
```

The last component would be used for various sweepstakes / promotions terms pages so they can easily have the same styling as our other legal pages. 
