### PR TITLE
added accordion prop to right align the arrow

### DIFF
--- a/docs/accordion.md
+++ b/docs/accordion.md
@@ -39,6 +39,14 @@ import { Accordion } from 'radiance-ui';
   >
     <div>Expansion</div>
   </Accordion>
+  <Accordion
+    title={<div>Title</div>}
+    isOpen={false}
+    onClick={() => {}}
+    rightAlignArrow
+  >
+    <div>Expansion</div>
+  </Accordion>
 </Accordion.Container>
 
 ```
@@ -46,14 +54,15 @@ import { Accordion } from 'radiance-ui';
 <!-- STORY -->
 
 ### Proptypes
-| prop     | propType           | required | default | description                                                                                                                  |
-|----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| title    | node               | yes      | -       | node that will render whether collapsed or expanded |
-| isOpen   | boolean            | yes      | -       | determine if the accordion is collapsed (false) or expanded (true) |
-| onClick  | function           | yes      | -       | invoked when title node is clicked |
-| children | node(s)            | yes      | -       | node(s) that will render only when expanded |
-| noBorder | boolean            | no       | false   | when true, border lines between accordions and title/children nodes will disappear |
-| disabled | boolean            | no       | false   | when true, the accordion will be greyed out and the onClick prop will be disabled |
+| prop            | propType | required | default | description                                                                                                                  |
+|-----------------|----------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
+| title           | node     | yes      | -       | node that will render whether collapsed or expanded |
+| isOpen          | boolean  | yes      | -       | determine if the accordion is collapsed (false) or expanded (true) |
+| onClick         | function | yes      | -       | invoked when title node is clicked |
+| children        | node(s)  | yes      | -       | node(s) that will render only when expanded |
+| noBorder        | boolean  | no       | false   | when true, border lines between accordions and title/children nodes will disappear |
+| disabled        | boolean  | no       | false   | when true, the accordion will be greyed out and the onClick prop will be disabled |
+| rightAlignArrow | boolean  | no       | false   | when true, the arrow is aligned flush with the right side of the component |
 
 
 ### Subcomponents

--- a/src/shared-components/accordion/index.js
+++ b/src/shared-components/accordion/index.js
@@ -24,11 +24,13 @@ class Accordion extends React.Component {
     children: PropTypes.node.isRequired,
     noBorder: PropTypes.bool,
     disabled: PropTypes.bool,
+    rightAlignArrow: PropTypes.bool,
   };
 
   static defaultProps = {
     noBorder: false,
     disabled: false,
+    rightAlignArrow: false,
   };
 
   static Container = Container;
@@ -82,6 +84,7 @@ class Accordion extends React.Component {
       children,
       noBorder,
       disabled,
+      rightAlignArrow,
     } = this.props;
 
     return (
@@ -92,7 +95,7 @@ class Accordion extends React.Component {
       >
         <TitleWrapper onClick={disabled ? noop : onClick} disabled={disabled}>
           <Truncate>{title}</Truncate>
-          <ArrowWrapper>
+          <ArrowWrapper rightAlign={rightAlignArrow}>
             <ChevronIcon
               rotate={isOpen ? 90 : 0}
               width={8}

--- a/src/shared-components/accordion/style.js
+++ b/src/shared-components/accordion/style.js
@@ -56,7 +56,11 @@ export const AccordionBox = styled.div`
 export const ArrowWrapper = styled.div`
   display: flex;
   align-items: center;
-  padding: 0 ${SPACER.medium};
+
+  ${({ rightAlign }) =>
+    rightAlign
+      ? `padding-left: ${SPACER.medium};`
+      : `padding: 0 ${SPACER.medium};`};
 `;
 
 export const TitleWrapper = styled.div`

--- a/stories/accordion/defaultAccordion.js
+++ b/stories/accordion/defaultAccordion.js
@@ -9,6 +9,7 @@ class DefaultAccordion extends React.Component {
     accordion2: false,
     accordion3: false,
     accordion4: false,
+    accordion5: false,
   };
 
   toggleAccordion = accordion => {
@@ -17,7 +18,7 @@ class DefaultAccordion extends React.Component {
 
   render() {
     const {
-      accordion1, accordion2, accordion3, accordion4, 
+      accordion1, accordion2, accordion3, accordion4, accordion5,
     } = this.state;
 
     return (
@@ -77,6 +78,18 @@ class DefaultAccordion extends React.Component {
             isOpen={accordion4}
             onClick={() => this.toggleAccordion('accordion4')}
             disabled
+          >
+            <Accordion.Content>Expandable</Accordion.Content>
+          </Accordion>
+          <Accordion
+            title={
+              <Accordion.Content>
+                This is a right aligned arrow
+              </Accordion.Content>
+            }
+            isOpen={accordion5}
+            onClick={() => this.toggleAccordion('accordion5')}
+            rightAlignArrow
           >
             <Accordion.Content>Expandable</Accordion.Content>
           </Accordion>

--- a/stories/accordion/index.js
+++ b/stories/accordion/index.js
@@ -50,6 +50,7 @@ stories.add(
               isOpen={boolean('isOpen', false)}
               noBorder={boolean('noBorder', false)}
               disabled={boolean('disabled', false)}
+              rightAlignArrow={boolean('rightAlignArrow', false)}
             >
               <Accordion.Content>
                 {text('Expanded text', 'Accordion expanded content')}


### PR DESCRIPTION
In this PR:
- Added an additional prop to Accordion for when the designs need the arrow to be flush on the right side of the accordion