### PR TITLE
Add Apercu Mono as a usable font in Radiance

### DIFF
--- a/src/constants/fonts/index.js
+++ b/src/constants/fonts/index.js
@@ -3,4 +3,6 @@ export default {
     "'nocturno', Georgia, TimesNewRoman, 'Times New Roman', Times, Baskerville, serif",
   baseFont:
     "'larssiet', 'Avant Garde', Avantgarde, 'Century Gothic', CenturyGothic, AppleGothic, Verdana, sans-serif",
+  monoFont:
+  "'apercu mono', 'Lucida Console', Monaco, monospace",
 };


### PR DESCRIPTION
**What:**

This PR adds Apercu Mono in Radiance as a usable font. 

To use it in your projects you'll need to declare the font from `assets.curology...`

I may have done something wrong with this, so please tell me what to fix if I did! 


**Note:**

There is some custom styling that needs to happen at the larger text sizes with Apercu, it involves letter spacing but after talking to @daigof it seems like it would be best to just leave that up to each use case / instance for now.