### PR TITLE
[Chore] Update button loading prop usage

### DIFF
--- a/docs/button/button.md
+++ b/docs/button/button.md
@@ -1,4 +1,5 @@
 # Button
+
 ## Usage
 
 ```jsx
@@ -13,14 +14,14 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button buttonType="quaternary">Quaternary Button</Button>
     <Button disabled>Disabled Button</Button>
 
-    <Button loading>Primary Loading</Button>
-    <Button loading buttonType="secondary">
+    <Button isLoading>Primary Loading</Button>
+    <Button isLoading buttonType="secondary">
       Secondary Loading
     </Button>
-    <Button buttonType="tertiary" loading>
+    <Button buttonType="tertiary" isLoading>
       Tertiary Loading
     </Button>
-    <Button buttonType="quaternary" loading>
+    <Button buttonType="quaternary" isLoading>
       Quaternary Loading
     </Button>
   </Button.Container>
@@ -40,36 +41,38 @@ import { CheckmarkIcon } from 'radiance-ui/lib/icons';
     <Button disabled icon={<CheckmarkIcon />}>
       Disabled Button
     </Button>
-    <Button loading icon={<CheckmarkIcon />}>
+    <Button isLoading icon={<CheckmarkIcon />}>
       Primary Loading
     </Button>
-    <Button loading buttonType="secondary" icon={<CheckmarkIcon />}>
+    <Button isLoading buttonType="secondary" icon={<CheckmarkIcon />}>
       Secondary Loading
     </Button>
-    <Button loading buttonType="tertiary" icon={<CheckmarkIcon />}>
+    <Button isLoading buttonType="tertiary" icon={<CheckmarkIcon />}>
       Tertiary Loading
     </Button>
-    <Button loading buttonType="quaternary" icon={<CheckmarkIcon />}>
+    <Button isLoading buttonType="quaternary" icon={<CheckmarkIcon />}>
       Quaternary Loading
     </Button>
   </Button.Container>
-</React.Fragment>
+</React.Fragment>;
 ```
 
 <!-- STORY -->
 
 ### Proptypes
-| prop     | propType           | required | default | description                                                                                                                  |
-|----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`. |
-| children | node | yes | - | node to be rendered inside the button.  Recommended to be the button text |
-| disabled | bool               | no       | false   | when disabled, click listener will not be called and the UI will look disabled |
-| icon | node | no | null | icon to render in the button. Recommended to use one of Radiance's icons |
-| loading  | bool               | no       | false   | renders loading state and prevents click listener from being called |
-| onClick   | func              | no      | () => {} | callback function called on click of the button |
-| textColor | string | no | '' | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
+
+| prop       | propType | required | default  | description                                                                                                                  |
+| ---------- | -------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| buttonType | string   | no       | primary  | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`.                   |
+| children   | node     | yes      | -        | node to be rendered inside the button. Recommended to be the button text                                                     |
+| disabled   | bool     | no       | false    | when disabled, click listener will not be called and the UI will look disabled                                               |
+| icon       | node     | no       | null     | icon to render in the button. Recommended to use one of Radiance's icons                                                     |
+| isLoading  | bool     | no       | false    | renders loading state and prevents click listener from being called                                                          |
+| onClick    | func     | no       | () => {} | callback function called on click of the button                                                                              |
+| textColor  | string   | no       | ''       | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
 
 ### Notes
+
 Buttons can be used as a main call-to-action (CTA). Try to avoid using
 buttons of the same `buttonType` next to each other since we want to
 guide the user towards one option.

--- a/docs/button/roundButton.md
+++ b/docs/button/roundButton.md
@@ -1,4 +1,5 @@
 # Round Button
+
 ## Usage
 
 ```jsx
@@ -20,11 +21,11 @@ import { CheckmarkIcon, ArrowRightIcon, ArrowLeftIcon, CloseIcon } from 'radianc
 <RoundButton buttonType="action" icon={<CloseIcon />} disabled>Action</RoundButton>
 
 // Loading
-<RoundButton icon={<ArrowLeftIcon />} loading>Primary</RoundButton>
-<RoundButton buttonType="secondary" icon={<ArrowRightIcon />} loading>Secondary</RoundButton>
-<RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} loading>Tertiary</RoundButton>
-<RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} loading>Quaternary</RoundButton>
-<RoundButton buttonType="action" icon={<CloseIcon />} loading>Action</RoundButton>
+<RoundButton icon={<ArrowLeftIcon />} isLoading>Primary</RoundButton>
+<RoundButton buttonType="secondary" icon={<ArrowRightIcon />} isLoading>Secondary</RoundButton>
+<RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} isLoading>Tertiary</RoundButton>
+<RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} isLoading>Quaternary</RoundButton>
+<RoundButton buttonType="action" icon={<CloseIcon />} isLoading>Action</RoundButton>
 
 // Within RoundButton.Container (with multi prop)
 <RoundButton.Container multi>
@@ -36,17 +37,19 @@ import { CheckmarkIcon, ArrowRightIcon, ArrowLeftIcon, CloseIcon } from 'radianc
 <!-- STORY -->
 
 ### Proptypes
-| prop     | propType           | required | default | description                                                                                                                  |
-|----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| buttonType | string | no      | primary       | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`, `action`. |
-| children | node | yes | - | node to be rendered inside the button.  Recommended to be the button text |
-| disabled | bool               | no       | false   | when disabled, click listener will not be called and the UI will look disabled |
-| icon | node | yes | null | icon to render in the button. Recommended to use one of Radiance's icons |
-| loading  | bool               | no       | false   | renders loading state and prevents click listener from being called |
-| onClick   | func              | no      | () => {} | callback function called on click of the button |
-| textColor | string | no | '' | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
+
+| prop       | propType | required | default  | description                                                                                                                  |
+| ---------- | -------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| buttonType | string   | no       | primary  | Determines the button's main style theme. Must be one of `primary`, `secondary`, `tertiary`, `quaternary`, `action`.         |
+| children   | node     | yes      | -        | node to be rendered inside the button. Recommended to be the button text                                                     |
+| disabled   | bool     | no       | false    | when disabled, click listener will not be called and the UI will look disabled                                               |
+| icon       | node     | yes      | null     | icon to render in the button. Recommended to use one of Radiance's icons                                                     |
+| isLoading  | bool     | no       | false    | renders loading state and prevents click listener from being called                                                          |
+| onClick    | func     | no       | () => {} | callback function called on click of the button                                                                              |
+| textColor  | string   | no       | ''       | color (as a string) that will override existing text, icon, and loading colors for the button (except when disabled is true) |
 
 ### Notes
+
 `<RoundButton />` behaves mostly the same as `<Button />` except that it
 requires an `icon` prop since that is the main content placed with in
 the round button. Any children of the component will be rendered

--- a/src/shared-components/button/__snapshots__/test.js.snap
+++ b/src/shared-components/button/__snapshots__/test.js.snap
@@ -233,18 +233,15 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
 <button
   className="emotion-6 emotion-7"
   disabled={true}
-  loading={false}
   onClick={[Function]}
   type="button"
 >
   <div
     className="emotion-2 emotion-3"
-    loading={false}
   >
     <svg />
     <span
       className="emotion-0 emotion-1"
-      loading={false}
     >
       Button Text
     </span>
@@ -252,7 +249,6 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
   <div
     className="emotion-4 emotion-5"
     disabled={true}
-    loading={false}
   >
     <div>
       <span />

--- a/src/shared-components/button/components/roundButton/__snapshots__/test.js.snap
+++ b/src/shared-components/button/components/roundButton/__snapshots__/test.js.snap
@@ -239,7 +239,6 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
   <button
     className="emotion-2 emotion-3"
     disabled={true}
-    loading={false}
     onClick={[Function]}
     type="button"
   >
@@ -247,7 +246,6 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
     <div
       className="emotion-0 emotion-1"
       disabled={true}
-      loading={false}
     >
       <div>
         <span />

--- a/src/shared-components/button/components/roundButton/index.js
+++ b/src/shared-components/button/components/roundButton/index.js
@@ -9,6 +9,19 @@ import {
   RoundButtonText,
   RoundButtonContainer,
 } from './style';
+import withDeprecationWarning from '../../../../utils/withDeprecationWarning';
+
+const deprecatedProperties = {
+  loading: "The 'loading' prop is deprecated. Use 'isLoading' instead.",
+};
+
+const isLoadingPropFunction = (props, propName, componentName) => {
+  if (props[propName] !== undefined) {
+    return new Error(
+      `'loading' prop will be deprecated in the next major release. Please rename 'loading' to 'isLoading' in ${componentName}`
+    );
+  }
+};
 
 const propTypes = {
   onClick: PropTypes.func,
@@ -21,6 +34,7 @@ const propTypes = {
     'quaternary',
     'action',
   ]),
+  loading: isLoadingPropFunction,
   isLoading: PropTypes.bool,
   icon: PropTypes.node.isRequired,
   textColor: PropTypes.string,
@@ -40,36 +54,41 @@ const RoundButton = ({
   disabled,
   children,
   buttonType,
+  loading,
   isLoading,
   icon,
   textColor,
   ...rest
-}) => (
-  <RoundButtonWrapper>
-    <RoundButtonBase
-      onClick={!disabled && !isLoading ? onClick : () => false}
-      disabled={disabled}
-      buttonType={buttonType}
-      isLoading={isLoading}
-      type="button"
-      textColor={textColor}
-      {...rest}
-    >
-      {icon}
-      <Loader
-        isLoading={isLoading}
+}) => {
+  const loadingVal = loading === undefined ? isLoading : loading;
+
+  return (
+    <RoundButtonWrapper>
+      <RoundButtonBase
+        onClick={!disabled && !isLoading ? onClick : () => false}
         disabled={disabled}
         buttonType={buttonType}
-        css={roundButtonLoader(disabled)}
+        isLoading={loadingVal}
+        type="button"
         textColor={textColor}
-      />
-    </RoundButtonBase>
-    {children && <RoundButtonText>{children}</RoundButtonText>}
-  </RoundButtonWrapper>
-);
+        {...rest}
+      >
+        {icon}
+        <Loader
+          isLoading={loadingVal}
+          disabled={disabled}
+          buttonType={buttonType}
+          css={roundButtonLoader(disabled)}
+          textColor={textColor}
+        />
+      </RoundButtonBase>
+      {children && <RoundButtonText>{children}</RoundButtonText>}
+    </RoundButtonWrapper>
+  );
+};
 
 RoundButton.propTypes = propTypes;
 RoundButton.defaultProps = defaultProps;
 RoundButton.Container = RoundButtonContainer;
 
-export default RoundButton;
+export default withDeprecationWarning(RoundButton, deprecatedProperties);

--- a/src/shared-components/button/components/roundButton/index.js
+++ b/src/shared-components/button/components/roundButton/index.js
@@ -21,7 +21,7 @@ const propTypes = {
     'quaternary',
     'action',
   ]),
-  loading: PropTypes.bool,
+  isLoading: PropTypes.bool,
   icon: PropTypes.node.isRequired,
   textColor: PropTypes.string,
 };
@@ -29,7 +29,7 @@ const propTypes = {
 const defaultProps = {
   disabled: false,
   buttonType: 'primary',
-  loading: false,
+  isLoading: false,
   onClick() {},
   children: '',
   textColor: '',
@@ -40,24 +40,24 @@ const RoundButton = ({
   disabled,
   children,
   buttonType,
-  loading,
+  isLoading,
   icon,
   textColor,
   ...rest
 }) => (
   <RoundButtonWrapper>
     <RoundButtonBase
-      onClick={!disabled && !loading ? onClick : () => false}
+      onClick={!disabled && !isLoading ? onClick : () => false}
       disabled={disabled}
       buttonType={buttonType}
-      loading={loading}
+      isLoading={isLoading}
       type="button"
       textColor={textColor}
       {...rest}
     >
       {icon}
       <Loader
-        loading={loading}
+        isLoading={isLoading}
         disabled={disabled}
         buttonType={buttonType}
         css={roundButtonLoader(disabled)}

--- a/src/shared-components/button/components/roundButton/style.js
+++ b/src/shared-components/button/components/roundButton/style.js
@@ -34,8 +34,8 @@ export const RoundButtonBase = styled(ButtonBase)`
   width: 48px;
   padding: 0;
 
-  ${({ loading, disabled }) =>
-    !loading &&
+  ${({ isLoading, disabled }) =>
+    !isLoading &&
     !disabled &&
     css`
       &:hover {
@@ -45,7 +45,7 @@ export const RoundButtonBase = styled(ButtonBase)`
     `};
 
   & > svg {
-    opacity: ${({ loading }) => (loading ? 0 : 1)};
+    opacity: ${({ isLoading }) => (isLoading ? 0 : 1)};
     transition: opacity ${ANIMATION.defaultTiming};
     margin: 0 auto;
   }

--- a/src/shared-components/button/components/roundButton/test.js
+++ b/src/shared-components/button/components/roundButton/test.js
@@ -53,7 +53,7 @@ describe('<RoundButton />', () => {
     it('should not be invoked if loading', () => {
       const spy = jest.fn();
       const wrapper = mount(
-        <RoundButton loading onClick={spy} icon={<CameraIcon />}>
+        <RoundButton isLoading onClick={spy} icon={<CameraIcon />}>
           Button Text
         </RoundButton>
       );

--- a/src/shared-components/button/index.js
+++ b/src/shared-components/button/index.js
@@ -5,6 +5,19 @@ import { css } from '@emotion/core';
 import Loader from './shared-components/loader';
 import Container from './shared-components/container';
 import { ButtonBase, ButtonText, ButtonContents } from './style';
+import withDeprecationWarning from '../../utils/withDeprecationWarning';
+
+const deprecatedProperties = {
+  loading: "The 'loading' prop is deprecated. Use 'isLoading' instead.",
+};
+
+const isLoadingPropFunction = (props, propName, componentName) => {
+  if (props[propName] !== undefined) {
+    return new Error(
+      `'loading' prop will be deprecated in the next major release. Please rename 'loading' to 'isLoading' in ${componentName}`
+    );
+  }
+};
 
 class Button extends React.Component {
   static Container = Container;
@@ -19,6 +32,7 @@ class Button extends React.Component {
       'tertiary',
       'quaternary',
     ]),
+    loading: isLoadingPropFunction,
     isLoading: PropTypes.bool,
     icon: PropTypes.node,
     textColor: PropTypes.string,
@@ -38,34 +52,41 @@ class Button extends React.Component {
       disabled,
       children,
       buttonType,
+      loading,
       isLoading,
       icon,
       textColor,
       ...rest
     } = this.props;
 
+    const loadingVal = loading === undefined ? isLoading : loading;
+
     return (
       <ButtonBase
         disabled={disabled}
-        onClick={!disabled && !isLoading ? onClick : event => event.preventDefault()}
+        onClick={
+          !disabled && !loadingVal ? onClick : event => event.preventDefault()
+        }
         buttonType={buttonType}
-        isLoading={isLoading}
+        isLoading={loadingVal}
         type="button"
         textColor={textColor}
         {...rest}
       >
-        <ButtonContents isLoading={isLoading} hasIcon={!!icon}>
+        <ButtonContents isLoading={loadingVal} hasIcon={!!icon}>
           {icon}
           <ButtonText
-            isLoading={isLoading}
+            isLoading={loadingVal}
             hasIcon={!!icon}
-            css={css`padding-top: 2px;`}
+            css={css`
+              padding-top: 2px;
+            `}
           >
             {children}
           </ButtonText>
         </ButtonContents>
         <Loader
-          isLoading={isLoading}
+          isLoading={loadingVal}
           disabled={disabled}
           buttonType={buttonType}
           textColor={textColor}
@@ -78,4 +99,4 @@ class Button extends React.Component {
 export LinkButton from './components/linkButton';
 export RoundButton from './components/roundButton';
 export TextButton from './components/textButton';
-export default Button;
+export default withDeprecationWarning(Button, deprecatedProperties);

--- a/src/shared-components/button/index.js
+++ b/src/shared-components/button/index.js
@@ -19,7 +19,7 @@ class Button extends React.Component {
       'tertiary',
       'quaternary',
     ]),
-    loading: PropTypes.bool,
+    isLoading: PropTypes.bool,
     icon: PropTypes.node,
     textColor: PropTypes.string,
   };
@@ -27,7 +27,7 @@ class Button extends React.Component {
   static defaultProps = {
     disabled: false,
     buttonType: 'primary',
-    loading: false,
+    isLoading: false,
     onClick() {},
     textColor: '',
   };
@@ -38,7 +38,7 @@ class Button extends React.Component {
       disabled,
       children,
       buttonType,
-      loading,
+      isLoading,
       icon,
       textColor,
       ...rest
@@ -47,17 +47,17 @@ class Button extends React.Component {
     return (
       <ButtonBase
         disabled={disabled}
-        onClick={!disabled && !loading ? onClick : event => event.preventDefault()}
+        onClick={!disabled && !isLoading ? onClick : event => event.preventDefault()}
         buttonType={buttonType}
-        loading={loading}
+        isLoading={isLoading}
         type="button"
         textColor={textColor}
         {...rest}
       >
-        <ButtonContents loading={loading} hasIcon={!!icon}>
+        <ButtonContents isLoading={isLoading} hasIcon={!!icon}>
           {icon}
           <ButtonText
-            loading={loading}
+            isLoading={isLoading}
             hasIcon={!!icon}
             css={css`padding-top: 2px;`}
           >
@@ -65,7 +65,7 @@ class Button extends React.Component {
           </ButtonText>
         </ButtonContents>
         <Loader
-          loading={loading}
+          isLoading={isLoading}
           disabled={disabled}
           buttonType={buttonType}
           textColor={textColor}

--- a/src/shared-components/button/shared-components/loader/index.js
+++ b/src/shared-components/button/shared-components/loader/index.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 
 import ButtonLoader from './style';
 
-const Loader = ({ loading, disabled, buttonType, className, textColor }) => (
+const Loader = ({ isLoading, disabled, buttonType, className, textColor }) => (
   <ButtonLoader
-    loading={loading}
+    isLoading={isLoading}
     disabled={disabled}
     buttonType={buttonType}
     className={className}
@@ -20,7 +20,7 @@ const Loader = ({ loading, disabled, buttonType, className, textColor }) => (
 );
 
 Loader.propTypes = {
-  loading: PropTypes.bool,
+  isLoading: PropTypes.bool,
   disabled: PropTypes.bool,
   buttonType: PropTypes.oneOf([
     'primary',

--- a/src/shared-components/button/shared-components/loader/style.js
+++ b/src/shared-components/button/shared-components/loader/style.js
@@ -36,7 +36,7 @@ const ButtonLoader = styled.div`
   top: 0;
   margin-top: -6px;
   width: 38px;
-  opacity: ${({ loading }) => (loading ? 1 : 0)};
+  opacity: ${({ isLoading }) => (isLoading ? 1 : 0)};
 
   & span {
     ${({ disabled, buttonType }) => {

--- a/src/shared-components/button/style.js
+++ b/src/shared-components/button/style.js
@@ -20,7 +20,7 @@ const primaryStyles = css`
   }
 `;
 
-const secondaryStyles = loading => css`
+const secondaryStyles = isLoading => css`
   background-color: transparent;
   border-color: ${COLORS.purple};
   color: ${COLORS.purple};
@@ -30,9 +30,9 @@ const secondaryStyles = loading => css`
   &:focus,
   &:not([href]):not([tabindex]):hover,
   &:not([href]):not([tabindex]):focus {
-    background-color: ${loading ? 'inherit' : COLORS.primary};
-    color: ${loading ? COLORS.primary : COLORS.white};
-    fill: ${loading ? 'inherit' : COLORS.white};
+    background-color: ${isLoading ? 'inherit' : COLORS.primary};
+    color: ${isLoading ? COLORS.primary : COLORS.white};
+    fill: ${isLoading ? 'inherit' : COLORS.white};
   }
 `;
 
@@ -59,16 +59,16 @@ const quaternaryStyles = css`
   }
 `;
 
-const actionStyles = loading => css`
+const actionStyles = isLoading => css`
   border-width: 1px;
   border-color: ${COLORS.border};
   background-color: ${COLORS.white};
   color: ${COLORS.purple100};
   fill: ${COLORS.purple100};
-  box-shadow: ${loading ? 'none' : BOX_SHADOWS.clickable};
+  box-shadow: ${isLoading ? 'none' : BOX_SHADOWS.clickable};
 
   &:hover {
-    box-shadow: ${loading ? 'none' : BOX_SHADOWS.clickableHover};
+    box-shadow: ${isLoading ? 'none' : BOX_SHADOWS.clickableHover};
   }
 `;
 
@@ -94,20 +94,20 @@ const disabledStyles = css`
   }
 `;
 
-function parseTheme(disabled, buttonType, loading) {
+function parseTheme(disabled, buttonType, isLoading) {
   if (disabled) {
     return disabledStyles;
   }
 
   switch (buttonType) {
     case 'secondary':
-      return secondaryStyles(loading);
+      return secondaryStyles(isLoading);
     case 'tertiary':
       return tertiaryStyles;
     case 'quaternary':
       return quaternaryStyles;
     case 'action':
-      return actionStyles(loading);
+      return actionStyles(isLoading);
     default:
       return primaryStyles;
   }
@@ -116,7 +116,7 @@ function parseTheme(disabled, buttonType, loading) {
 export const baseButtonStyles = ({
   disabled,
   buttonType,
-  loading,
+  isLoading,
   textColor,
 }) => css`
   ${TYPOGRAPHY_STYLE.button};
@@ -146,8 +146,8 @@ export const baseButtonStyles = ({
     outline: none;
   }
 
-  ${parseTheme(disabled, buttonType, loading)};
-  ${loading && loadingStyles};
+  ${parseTheme(disabled, buttonType, isLoading)};
+  ${isLoading && loadingStyles};
 
   ${!!textColor &&
     !disabled &&
@@ -168,14 +168,14 @@ export const ButtonContents = styled.div`
   transition: transform ${ANIMATION.defaultTiming};
   width: 100%;
 
-  ${({ loading, hasIcon }) => {
-    if (loading && hasIcon) {
+  ${({ isLoading, hasIcon }) => {
+    if (isLoading && hasIcon) {
       return css`
         transform: translateX(-30px);
       `;
     }
 
-    if (loading && !hasIcon) {
+    if (isLoading && !hasIcon) {
       return css`
         transform: translateX(-15px);
       `;
@@ -187,7 +187,7 @@ export const ButtonContents = styled.div`
   }};
 
   & > svg {
-    opacity: ${({ loading }) => (loading ? 0 : 1)};
+    opacity: ${({ isLoading }) => (isLoading ? 0 : 1)};
     transition: opacity ${ANIMATION.defaultTiming};
     margin-right: ${SPACER.medium};
     margin-top: -5px;
@@ -199,8 +199,8 @@ export const ButtonText = styled.span`
   margin: 0;
   padding-top: 2px;
 
-  ${({ loading, hasIcon }) => {
-    if (loading && !hasIcon) {
+  ${({ isLoading, hasIcon }) => {
+    if (isLoading && !hasIcon) {
       return css`
         padding-left: ${SPACER.medium};
       `;

--- a/src/shared-components/button/test.js
+++ b/src/shared-components/button/test.js
@@ -45,7 +45,7 @@ describe('<Button />', () => {
     it('should not be invoked if loading', () => {
       const spy = jest.fn();
       const button = mount(
-        <Button loading onClick={spy}>
+        <Button isLoading onClick={spy}>
           Button Text
         </Button>
       );

--- a/stories/button/button/index.js
+++ b/stories/button/button/index.js
@@ -31,14 +31,14 @@ const ButtonStory = withDocs(ButtonReadme, () => (
       <Button buttonType="quaternary">Quaternary Button</Button>
       <Button disabled>Disabled Button</Button>
 
-      <Button loading>Primary Loading</Button>
-      <Button loading buttonType="secondary">
+      <Button isLoading>Primary Loading</Button>
+      <Button isLoading buttonType="secondary">
         Secondary Loading
       </Button>
-      <Button buttonType="tertiary" loading>
+      <Button buttonType="tertiary" isLoading>
         Tertiary Loading
       </Button>
-      <Button buttonType="quaternary" loading>
+      <Button buttonType="quaternary" isLoading>
         Quaternary Loading
       </Button>
     </Button.Container>
@@ -71,16 +71,16 @@ const ButtonStory = withDocs(ButtonReadme, () => (
         Disabled Button
       </Button>
 
-      <Button loading icon={<CheckmarkIcon />}>
+      <Button isLoading icon={<CheckmarkIcon />}>
         Primary Loading
       </Button>
-      <Button loading buttonType="secondary" icon={<CheckmarkIcon />}>
+      <Button isLoading buttonType="secondary" icon={<CheckmarkIcon />}>
         Secondary Loading
       </Button>
-      <Button loading buttonType="tertiary" icon={<CheckmarkIcon />}>
+      <Button isLoading buttonType="tertiary" icon={<CheckmarkIcon />}>
         Tertiary Loading
       </Button>
-      <Button loading buttonType="quaternary" icon={<CheckmarkIcon />}>
+      <Button isLoading buttonType="quaternary" icon={<CheckmarkIcon />}>
         Quaternary Loading
       </Button>
     </Button.Container>
@@ -98,7 +98,7 @@ const ButtonStory = withDocs(ButtonReadme, () => (
         ['primary', 'secondary', 'tertiary', 'quaternary'],
         'primary'
       )}
-      loading={boolean('loading', false)}
+      isLoading={boolean('isLoading', false)}
       disabled={boolean('disabled', false)}
       onClick={action('button clicked')}
       textColor={text('textColor', '')}

--- a/stories/button/roundButton/index.js
+++ b/stories/button/roundButton/index.js
@@ -75,23 +75,23 @@ const RoundButtonStory = withDocs(RoundButtonReadme, () => (
 
     <Typography.Title>Loading</Typography.Title>
     <ButtonsContainer>
-      <RoundButton icon={<ArrowLeftIcon />} loading>
+      <RoundButton icon={<ArrowLeftIcon />} isLoading>
         Primary
       </RoundButton>
 
-      <RoundButton buttonType="secondary" icon={<ArrowRightIcon />} loading>
+      <RoundButton buttonType="secondary" icon={<ArrowRightIcon />} isLoading>
         Secondary
       </RoundButton>
 
-      <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} loading>
+      <RoundButton buttonType="tertiary" icon={<ArrowLeftIcon />} isLoading>
         Tertiary
       </RoundButton>
 
-      <RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} loading>
+      <RoundButton buttonType="quaternary" icon={<ArrowRightIcon />} isLoading>
         Quaternary
       </RoundButton>
 
-      <RoundButton buttonType="action" icon={<CloseIcon />} loading>
+      <RoundButton buttonType="action" icon={<CloseIcon />} isLoading>
         Action
       </RoundButton>
     </ButtonsContainer>
@@ -121,7 +121,7 @@ const RoundButtonStory = withDocs(RoundButtonReadme, () => (
           ['primary', 'secondary', 'tertiary', 'quaternary', 'action'],
           'primary'
         )}
-        loading={boolean('loading', false)}
+        isLoading={boolean('isLoading', false)}
         disabled={boolean('disabled', false)}
         onClick={action('button clicked')}
         icon={<CheckmarkIcon />}


### PR DESCRIPTION
### What & Why

1. Corrects warnings logged in #124 related to passing non-boolean `loading` attribute to the DOM by renaming all usage in `<Button />` and `<RoundButton />` to `isLoading`. 
1. Adds a deprecation notice to use of `loading`

### Other
- Once this is merged in, I intend to release Radiance with a minor bump to update our emotion use. I'll then make the necessary changes in PocketDerm before then removing the deprecation warning. (Gatsby does not use this prop, though it looks like it is present in exactly one snapshot, due to it being a defaultProp). 
