### PR TITLE
Feature/update lint staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run build:svgs:index && yarn run lint-staged"
+      "pre-commit": "yarn run build:svgs:index && yarn run lint-staged",
+      "pre-push": "yarn run test"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "concurrent": false,
     "subTaskConcurrency": 1,
     "linters": {
-      "resources/**/!(style|styles|test).js": [
+      "!(style|styles|test).js": [
         "prettier --write --single-quote",
         "eslint --fix",
         "git add"

--- a/package.json
+++ b/package.json
@@ -134,6 +134,10 @@
         "prettier --write --single-quote",
         "eslint --fix",
         "git add"
+      ],
+      "*.{md,json}": [
+        "prettier --write",
+        "git add"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "subTaskConcurrency": 1,
     "linters": {
       "!(style|styles|test).js": [
-        "prettier --write --single-quote",
+        "prettier --write",
         "eslint --fix",
         "git add"
       ],

--- a/package.json
+++ b/package.json
@@ -135,6 +135,10 @@
         "eslint --fix",
         "git add"
       ],
+      "(style|styles|test).js": [
+        "prettier --write",
+        "git add"
+      ],
       "*.{md,json}": [
         "prettier --write",
         "git add"


### PR DESCRIPTION
This PR expands our `husky` and `lint-staged` use. 

1. It adds a pre-push `yarn run test` hook so that we can find and fix tests before they fail on CI. 
1. It applies `prettier` formatting to `.md` and `.json` files
    - This applies, most significantly, to our manual markdown prop tables. Ideally, we can start pulling them automatically from the component, but we are not doing that yet. 
1. It applies `prettier` formatting to `style/styles/test.js` files.
    - This makes an assumption that we were originally ignoring these files because we didn't want to run `eslint` on them. I still think we should format them. 
1. It applies `prettier` formatting and `eslint` checking on other source files.
    - It looks like there was an incorrect path to these files in that `resources` does not exist in this repo, so we were neither applying `prettier` nor checking for `eslint` warnings/errors before pushing. 

The intent of this (and #129) is to make greater use of the tools we're using offer. I think we should rely more on auto-formatting to ensure a consistent code style (so we don't have to comment on it in PRs, and so it is easier to read), and to prevent unnecessary CI builds. 