### PR TITLE
Feature/expand jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,14 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['src/shared-components/**', '/src/utils/**', '!src/**/__snapshots__/**.js.snap'],
-  snapshotSerializers: ['jest-emotion'],
-  setupFilesAfterEnv: ['<rootDir>tests/setupTests.js'],
-  testPathIgnorePatterns: ['/node_modules/', '/lib/', '/__snapshots__'],
+  collectCoverageFrom: [
+    'src/shared-components/**',
+    '/src/utils/**',
+    '!src/**/__snapshots__/**.js.snap',
+  ],
   moduleNameMapper: {
     '\\.svg': '<rootDir>/tests/__mocks__/svgMock.js',
   },
+  setupFilesAfterEnv: ['<rootDir>tests/setupTests.js'],
+  snapshotSerializers: ['jest-emotion'],
+  testPathIgnorePatterns: ['/node_modules/', '/lib/', '/__snapshots__'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,14 @@ module.exports = {
     '/src/utils/**',
     '!src/**/__snapshots__/**.js.snap',
   ],
+  coverageThreshold: {
+    global: {
+      branches: 50,
+      functions: 66,
+      lines: 75,
+      statements: 75,
+    },
+  },
   moduleNameMapper: {
     '\\.svg': '<rootDir>/tests/__mocks__/svgMock.js',
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   collectCoverageFrom: [
     'src/shared-components/**',
     '/src/utils/**',
-    '!src/**/__snapshots__/**.js.snap',
+    '!src/**/__snapshots__/*.js.snap',
   ],
   coverageThreshold: {
     global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,9 @@
-const { defaults } = require('jest-config');
-
 module.exports = {
+  collectCoverage: true,
+  collectCoverageFrom: ['src/shared-components/**', '/src/utils/**', '!src/**/__snapshots__/**.js.snap'],
   snapshotSerializers: ['jest-emotion'],
-  setupFilesAfterEnv: ["<rootDir>tests/setupTests.js"],
-  testPathIgnorePatterns: [...defaults.testPathIgnorePatterns, "/lib/"],
+  setupFilesAfterEnv: ['<rootDir>tests/setupTests.js'],
+  testPathIgnorePatterns: ['/node_modules/', '/lib/', '/__snapshots__'],
   moduleNameMapper: {
     '\\.svg': '<rootDir>/tests/__mocks__/svgMock.js',
   },


### PR DESCRIPTION
This PR expands our `jest.config.js` file. 

1. It removes the `jest-config` import because we're only relying on it to ignore `node_modules`. It's clearer to include that explicitly. 
1. It adds coverage thresholds to our components (that currently pass) so we can maintain sufficient code coverages on the components, and enforce it. 

The intent of this (and #130) is to make greater use of the tools we're using offer. In particular the coverage thresholds will help us stay sharp when we make changes and/or add components to the library, to ensure that we're including sufficient testing for those changes. 