### PR TITLE
Fix option-button bug

### DIFF
--- a/src/shared-components/optionButton/__snapshots__/test.js.snap
+++ b/src/shared-components/optionButton/__snapshots__/test.js.snap
@@ -52,6 +52,9 @@ exports[`<OptionButton /> UI snapshots checkbox selected, without custom icon 1`
   -webkit-flex-flow: row nowrap;
   -ms-flex-flow: row nowrap;
   flex-flow: row nowrap;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -181,6 +184,9 @@ exports[`<OptionButton /> UI snapshots radio unselected, with icon node prop 1`]
   -webkit-flex-flow: row nowrap;
   -ms-flex-flow: row nowrap;
   flex-flow: row nowrap;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/src/shared-components/optionButton/style.js
+++ b/src/shared-components/optionButton/style.js
@@ -48,6 +48,7 @@ const getBaseIconWrapperStyles = ({ selected, optionType, type }) => css`
   height: 32px;
   display: flex;
   flex-flow: row nowrap;
+  flex: 0 0 auto;
   justify-content: center;
   align-items: center;
   transition: all ${ANIMATION.defaultTiming};


### PR DESCRIPTION
**What**

@mvandy found an issue in the consult questionnaire that caused the option buttons to squish the checkmarks at smaller screen sizes / longer text blocks. 

![image](https://user-images.githubusercontent.com/28582716/60930523-d7aa3500-a26a-11e9-972f-d6442c9b1293.png)

This PR adds `flex: 0 0 auto;` to the component which will allow the checkbox / radio to retain its size. 

I haven't checked if this impacts production in any way. I can't imagine it would, but just thought I'd point that out.