### PR TITLE
Fix select dropdown on mobile with disabled default value as selected

### DIFF
--- a/src/shared-components/dropdown/index.js
+++ b/src/shared-components/dropdown/index.js
@@ -28,27 +28,35 @@ const propTypes = {
 class Dropdown extends React.Component {
   state = { isOpen: false };
 
-  onSelectClick = () => this.setState({ isOpen: !this.state.isOpen });
+  onSelectClick = () => {
+    const { isOpen } = this.state;
+
+    this.setState({ isOpen: !isOpen });
+  };
 
   onSelectChange = event => {
+    const { onChange } = this.props;
+
     const { value, selectedOptions } = event.target;
 
     if (selectedOptions && selectedOptions.length) {
       const { label } = selectedOptions[0];
-      this.props.onChange({ value, label });
+      onChange({ value, label });
     }
 
     this.closeDropdown();
   };
 
   onOptionClick = event => {
+    const { onChange } = this.props;
+
     if (event.target.hasAttribute('disabled')) {
       return;
     }
-    
+
     const value = event.target.getAttribute('value');
     const label = event.target.innerText;
-    this.props.onChange({ value, label });
+    onChange({ value, label });
     this.closeDropdown();
   };
 

--- a/src/shared-components/dropdown/mobileDropdown.js
+++ b/src/shared-components/dropdown/mobileDropdown.js
@@ -13,15 +13,25 @@ const MobileDropdown = ({
       value={value || ''}
       onChange={onSelectChange}
     >
-      {options.map(option => (
-        <option
-          key={option.value}
-          value={option.value}
-          disabled={option.disabled}
-        >
-          {option.label}
-        </option>
-      ))}
+      {options.map(option => {
+        let disabledValue = option.disabled;
+
+        // Covers the case where default value is disabled
+        // In mobile you cannot have a selected value as disabled option
+        if (option.value === value) {
+          disabledValue = false;
+        }
+
+        return (
+          <option
+            key={option.value}
+            value={option.value}
+            disabled={disabledValue}
+          >
+            {option.label}
+          </option>
+        );
+      })}
     </select>
     <IconContainer>
       <ChevronIcon width={10} height={10} />

--- a/src/shared-components/dropdown/mobileDropdown.js
+++ b/src/shared-components/dropdown/mobileDropdown.js
@@ -14,7 +14,7 @@ const MobileDropdown = ({
       onChange={onSelectChange}
     >
       {options.map(option => {
-        let isDisabled = !!option.disabled;
+        let isDisabled = option.disabled;
 
         // Covers the case where default value is disabled
         // In mobile you cannot have a selected value as disabled option

--- a/src/shared-components/dropdown/mobileDropdown.js
+++ b/src/shared-components/dropdown/mobileDropdown.js
@@ -14,20 +14,16 @@ const MobileDropdown = ({
       onChange={onSelectChange}
     >
       {options.map(option => {
-        let disabledValue = option.disabled;
+        let isDisabled = !!option.disabled;
 
         // Covers the case where default value is disabled
         // In mobile you cannot have a selected value as disabled option
         if (option.value === value) {
-          disabledValue = false;
+          isDisabled = false;
         }
 
         return (
-          <option
-            key={option.value}
-            value={option.value}
-            disabled={disabledValue}
-          >
+          <option key={option.value} value={option.value} disabled={isDisabled}>
             {option.label}
           </option>
         );


### PR DESCRIPTION
- Part of https://app.asana.com/0/1130276194470636/1135497036319695/f
- In this case we are passing a default selected value that is also disabled
- In desktop works OK because is  custom  
- in mobile we have a `select` tag so when we try to select a disabled option it doesnt work and skip to the next undisabled value causing the bug
- This fix is smart enough that once you select a value, the previous default become disabled so you cannot go back and select that again