### PR TITLE
Update accordion to determine height after mount

### DIFF
--- a/src/shared-components/accordion/index.js
+++ b/src/shared-components/accordion/index.js
@@ -50,11 +50,10 @@ class Accordion extends React.Component {
 
   contentRef = React.createRef();
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      contentHeight: this.getContentHeight(props.isOpen),
-    };
+  state = { contentHeight: '0px' };
+
+  componentDidMount() {
+    this.updateHeight();
   }
 
   componentDidUpdate() {
@@ -68,16 +67,16 @@ class Accordion extends React.Component {
         ? this.contentRef.current.clientHeight
         : '0'
     }px`
-  )
+  );
 
   updateHeight() {
     const { isOpen } = this.props;
     const { contentHeight } = this.state;
 
-    if (contentHeight !== this.getContentHeight(isOpen)) {
-      this.setState({
-        contentHeight: this.getContentHeight(isOpen),
-      });
+    const nextHeight = this.getContentHeight(isOpen);
+
+    if (contentHeight !== nextHeight) {
+      this.setState({ contentHeight: nextHeight });
     }
   }
 


### PR DESCRIPTION
This fixes a small issue where the Accordion wouldn't render open if the `isOpen` prop is initially `true`. 

We're using a `ref` to determine content height inside the accordion, but we were attempting to set the height before we had access to the node, thus it was still mounting as '0px'.

This PR waits for node availability and then updates the height in `componentDidMount`.

@heyamykate --  RE: [this PR](https://github.com/PocketDerm/PocketDerm/pull/6633) -- I think this is why the photo upload accordion originally had the `currentPerspective` set to null, then it would update on mount so the accordion would actually open. Right now, it loads as open but the content height is still set to '0px', so users need to click it twice to get it to expand.