### PR TITLE
Allow node proptype for OptionButton subtext

### DIFF
--- a/src/shared-components/optionButton/index.js
+++ b/src/shared-components/optionButton/index.js
@@ -48,7 +48,7 @@ const OptionButton = ({
 OptionButton.propTypes = {
   icon: PropTypes.node,
   text: PropTypes.string.isRequired,
-  subtext: PropTypes.string,
+  subtext: PropTypes.node,
   onClick: PropTypes.func.isRequired,
   optionType: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
   selected: PropTypes.bool,


### PR DESCRIPTION
Updating the `subtext` proptype to `node`. 

I'm working on a design in which I need to use a component instead of a string.

<img width="514" alt="Screen Shot 2019-10-08 at 2 11 03 PM" src="https://user-images.githubusercontent.com/38407520/66433605-7d3d8380-e9d5-11e9-999a-91059b76e21e.png">
