### PR TITLE
[Chore] Update LinkButton as prop option from func to elementType

### DIFF
--- a/src/shared-components/button/components/linkButton/index.js
+++ b/src/shared-components/button/components/linkButton/index.js
@@ -8,8 +8,13 @@ import { linkButtonStyles } from './style';
 const propTypes = {
   disabled: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  buttonType: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'quaternary']),
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  buttonType: PropTypes.oneOf([
+    'primary',
+    'secondary',
+    'tertiary',
+    'quaternary',
+  ]),
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   onClick: PropTypes.func,
 };
 


### PR DESCRIPTION
[`react-router-dom v5.1.0`](https://github.com/ReactTraining/react-router/releases/tag/v5.1.0) changes the `Link` component in such a manner that when we pass it as the `as` prop to `LinkButton` we get a prop type error, because it is no longer a `func` but rather an `elementType`.