### PR TITLE
[Dependencies] Bump prop-types from 15.6.2 to 15.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "@emotion/core": "10.0.10",
     "@emotion/styled": "10.0.10",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-modal": "^3.8.1",
     "react-slick": "^0.23.2",


### PR DESCRIPTION
Our test suite logs prop-types warnings/errors. Even though this update doesn't change our `yarn.lock` it seems to fix the issue. 

We should probably do an audit of our dependencies soon and fix a lot of low-hanging fruit with outdated dependencies. 