### PR TITLE
Add tag ID prop to modal container

### DIFF
--- a/src/shared-components/immersiveModal/index.js
+++ b/src/shared-components/immersiveModal/index.js
@@ -23,11 +23,13 @@ class ImmersiveModal extends React.Component {
     canBeClosed: PropTypes.bool,
     onClose: PropTypes.func,
     header: PropTypes.node,
+    scrollContainerId: PropTypes.string,
   };
 
   static defaultProps = {
     canBeClosed: true,
     onClose: () => {},
+    scrollContainerId: 'modalScrollContainer',
   };
 
   static Title = Title;
@@ -75,11 +77,16 @@ class ImmersiveModal extends React.Component {
 
   render() {
     const {
-      children, canBeClosed, onClose, header, ...rest 
+      children,
+      canBeClosed,
+      onClose,
+      header,
+      scrollContainerId,
+      ...rest
     } = this.props;
     return ReactDOM.createPortal(
       <Overlay {...rest}>
-        <ModalContainer>
+        <ModalContainer id={scrollContainerId}>
           <OffClickWrapper onOffClick={this.closeModal}>
             {canBeClosed && (
               <CloseIconContainer>


### PR DESCRIPTION
I'm building out a modal where I need to target the modal container so I can implement some scrolling functionality. I can't target the outer container because the scrolling context is on the modal container. This adds a `scrollContainerId` prop that will pass down an ID so we can access the context.

![learnMoreModal](https://user-images.githubusercontent.com/38407520/67715965-15e97280-f988-11e9-924b-83a628845537.gif)