### PR TITLE
[Patch] Sequence onExit callback after setState in Alert component

### DIFF
--- a/src/shared-components/alert/index.js
+++ b/src/shared-components/alert/index.js
@@ -66,8 +66,8 @@ class Alert extends React.Component {
 
     // eslint-disable-next-line no-undef
     window.setTimeout(() => {
-      onExit({ ...rest });
       this.setState({ exited: true });
+      onExit({ ...rest });
     }, ANIMATION_DELAY);
   };
 


### PR DESCRIPTION
Development logs a `setState` on unmounted component warning for all `Alerts` when we transition them off the screen.

![image](https://user-images.githubusercontent.com/13544620/68430558-1db5cd80-0165-11ea-80db-b163e9554220.png)

I looked into it and this one-line change fixes the issue. I preferred the diff to using a callback in `setState` (e.g. `this.setState({ exited: true }, () => onExit({ ...rest }));`) to try and change behavior as little as possible. 